### PR TITLE
Project cleanup

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Itty Bitty Apps Pty Ltd
+Copyright (c) 2015-2016, Itty Bitty Apps Pty Ltd
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/Revert-tvOS/Sources/RevertFocusableTableView.swift
+++ b/Revert-tvOS/Sources/RevertFocusableTableView.swift
@@ -1,6 +1,5 @@
 //
 //  Copyright © 2016 Itty Bitty Apps. All rights reserved.
-//
 
 import UIKit
 

--- a/Revert-tvOS/Sources/RevertSplitViewController.swift
+++ b/Revert-tvOS/Sources/RevertSplitViewController.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import UIKit
 

--- a/Revert.xcodeproj/project.pbxproj
+++ b/Revert.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		9A6850C71AD4A20E00ACCE29 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A6850C61AD4A20E00ACCE29 /* Images.xcassets */; };
 		9A6C75041BDE29DE00534680 /* Info in Resources */ = {isa = PBXBuildFile; fileRef = 9A6C75021BDE29DE00534680 /* Info */; };
 		9A87FA761ADC91B800290F7A /* KeyboardHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A87FA751ADC91B800290F7A /* KeyboardHandler.swift */; };
+		9AABB7251D2E0D8300D162B2 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 9A0416CC1B02EAB300477E60 /* Localizable.stringsdict */; };
 		9ABEBA111AD4AC1400E3D998 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABEBA101AD4AC1400E3D998 /* AppDelegate.swift */; };
 		9AE252511B18211A002B596C /* InfoBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE252501B18211A002B596C /* InfoBuilder.swift */; };
 		9AEE22B21ADBADB10033DAA2 /* BarsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEE22B11ADBADB10033DAA2 /* BarsViewController.swift */; };
@@ -290,14 +291,6 @@
 			name = "Storyboards & XIBs";
 			sourceTree = "<group>";
 		};
-		9A17423C1B09CFAC00BEDFAB /* Strings */ = {
-			isa = PBXGroup;
-			children = (
-				9A0416CC1B02EAB300477E60 /* Localizable.stringsdict */,
-			);
-			name = Strings;
-			sourceTree = "<group>";
-		};
 		9A1B1AC11ADCF2BA0016B793 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -343,7 +336,6 @@
 				9A6C75021BDE29DE00534680 /* Info */,
 				9A0416C01B02EA7F00477E60 /* Info.plist */,
 				9A17423B1B09CF9C00BEDFAB /* Storyboards & XIBs */,
-				9A17423C1B09CFAC00BEDFAB /* Strings */,
 			);
 			name = Resources;
 			path = Revert;
@@ -584,6 +576,7 @@
 			children = (
 				BB9F76911CB628C4006EA285 /* Data */,
 				BB735B451C9FD0490092FA6F /* Assets.xcassets */,
+				9A0416CC1B02EAB300477E60 /* Localizable.stringsdict */,
 			);
 			name = Resources;
 			path = ../..;
@@ -798,6 +791,7 @@
 				BB2720BC1C9F8BE5002E53EE /* HomeCell.xib in Resources */,
 				BB735B471C9FD0490092FA6F /* Assets.xcassets in Resources */,
 				BB9F76931CB628C4006EA285 /* Data in Resources */,
+				9AABB7251D2E0D8300D162B2 /* Localizable.stringsdict in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -963,6 +957,7 @@
 				9A0416CD1B02EAB300477E60 /* Base */,
 			);
 			name = Localizable.stringsdict;
+			path = Revert;
 			sourceTree = "<group>";
 		};
 		9A6850C31AD4A20E00ACCE29 /* Main.storyboard */ = {

--- a/Revert/Base.lproj/Main.storyboard
+++ b/Revert/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="H1p-Uh-vWS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="H1p-Uh-vWS">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -34,7 +34,7 @@
         <!--Arranged Views-->
         <scene sceneID="5P7-68-gkb">
             <objects>
-                <viewController id="TC2-p2-DN9" customClass="RevertViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="TC2-p2-DN9" customClass="RevertViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="ErB-La-4G3"/>
                         <viewControllerLayoutGuide type="bottom" id="Uxt-hp-ALN"/>
@@ -71,7 +71,7 @@
                                                 <rect key="frame" x="27" y="477" width="442" height="1"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="Gn3-E9-Vej" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="height" constant="1" id="Gn3-E9-Vej" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -83,7 +83,7 @@
                                                 <rect key="frame" x="27" y="18" width="442" height="1"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="pvI-5g-07b" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="height" constant="1" id="pvI-5g-07b" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -95,7 +95,7 @@
                                                 <rect key="frame" x="18" y="27" width="1" height="442"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="1" id="y6P-DN-ylq" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="width" constant="1" id="y6P-DN-ylq" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -107,7 +107,7 @@
                                                 <rect key="frame" x="477" y="27" width="1" height="442"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="1" id="I18-iO-8UK" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="width" constant="1" id="I18-iO-8UK" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -227,12 +227,12 @@
         <!--Collection View-->
         <scene sceneID="D4X-ca-JVA">
             <objects>
-                <collectionViewController id="V4s-a2-462" customClass="CollectionViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController id="V4s-a2-462" customClass="CollectionViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="7bY-VM-wmY">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
-                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="1iK-vo-exA" customClass="DualRowBasicCollectionViewFlowLayout" customModule="Revert" customModuleProvider="target">
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="1iK-vo-exA" customClass="DualRowBasicCollectionViewFlowLayout" customModule="Revert_iOS" customModuleProvider="target">
                             <size key="itemSize" width="200" height="50"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
@@ -307,18 +307,18 @@
         <!--Table View-->
         <scene sceneID="SSy-q8-ncv">
             <objects>
-                <tableViewController id="1Hy-ss-Q90" customClass="CountriesViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="1Hy-ss-Q90" customClass="CountriesViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" allowsMultipleSelection="YES" rowHeight="50" sectionHeaderHeight="22" sectionFooterHeight="22" id="pUr-dH-r7C">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94907671213150024" green="0.94865018129348755" blue="0.96507126092910767" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="tintColor" red="0.0" green="0.68914401531219482" blue="0.94865745306015015" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="TableViewControllerCell" id="zZi-sn-xOK" customClass="BasicCell" customModule="Revert" customModuleProvider="target">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="TableViewControllerCell" id="zZi-sn-xOK" customClass="BasicCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="86" width="600" height="50"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zZi-sn-xOK" id="p0d-PK-Oep">
-                                    <rect key="frame" x="0.0" y="0.0" width="561" height="50"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="561" height="49"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z76-Yq-qd9">
@@ -379,7 +379,7 @@
         <!--Map View-->
         <scene sceneID="Vd8-iN-gNO">
             <objects>
-                <viewController id="OzG-CK-fgG" customClass="MapViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="OzG-CK-fgG" customClass="MapViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="LtO-Cz-6mw"/>
                         <viewControllerLayoutGuide type="bottom" id="ouM-xa-wey"/>
@@ -443,7 +443,7 @@
         <!--Scroll View-->
         <scene sceneID="btv-V6-pFl">
             <objects>
-                <viewController id="e6c-PC-ss8" customClass="ScrollViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="e6c-PC-ss8" customClass="ScrollViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="D5f-xu-F5y"/>
                         <viewControllerLayoutGuide type="bottom" id="16M-Fu-qLY"/>
@@ -571,7 +571,7 @@
         <!--Bars-->
         <scene sceneID="ip3-U8-Acg">
             <objects>
-                <viewController id="vVt-7j-5QX" customClass="BarsViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="vVt-7j-5QX" customClass="BarsViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Uoj-Fd-V2E"/>
                         <viewControllerLayoutGuide type="bottom" id="Pgp-LK-lBc"/>
@@ -711,19 +711,19 @@
         <!--Controls-->
         <scene sceneID="ErH-9w-JqK">
             <objects>
-                <collectionViewController id="mzs-Le-LGO" customClass="ControlsViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController id="mzs-Le-LGO" customClass="ControlsViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="interactive" dataMode="prototypes" id="3Ef-aw-TQh">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
-                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="pCw-6n-daR" customClass="AdaptiveCollectionViewFlowLayout" customModule="Revert" customModuleProvider="target">
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="pCw-6n-daR" customClass="AdaptiveCollectionViewFlowLayout" customModule="Revert_iOS" customModuleProvider="target">
                             <size key="itemSize" width="298" height="298"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
                             <inset key="sectionInset" minX="1" minY="0.0" maxX="1" maxY="35"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SegmentedControlTitleCell" id="wsb-4D-NCp" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SegmentedControlTitleCell" id="wsb-4D-NCp" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="64" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -784,7 +784,7 @@
                                     <outlet property="titleLabel" destination="ThI-Ia-sbg" id="rb4-PC-Vud"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SegmentedControlImageCell" id="sh4-bE-1pX" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SegmentedControlImageCell" id="sh4-bE-1pX" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="64" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -844,7 +844,7 @@
                                     <outlet property="titleLabel" destination="tUG-q2-Eg8" id="39v-on-CSV"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="StepperCell" id="Q2F-hV-JRH" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="StepperCell" id="Q2F-hV-JRH" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="363" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -886,7 +886,7 @@
                                     <outlet property="titleLabel" destination="yw5-SN-FZL" id="Ee0-FW-QRO"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SwitchCell" id="s1l-Fu-khN" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SwitchCell" id="s1l-Fu-khN" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="363" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -928,7 +928,7 @@
                                     <outlet property="titleLabel" destination="6ls-lH-dE2" id="aKq-mn-UkO"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SliderCell" id="eA1-Vs-lgr" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SliderCell" id="eA1-Vs-lgr" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="662" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -973,7 +973,7 @@
                                     <outlet property="titleLabel" destination="DoD-yq-9M9" id="Yhj-4Y-QIz"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PageControlCell" id="Kni-Pw-ESJ" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PageControlCell" id="Kni-Pw-ESJ" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="662" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1020,7 +1020,7 @@
                                     <outlet property="titleLabel" destination="tqy-3i-FJs" id="gNm-5w-cQ8"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TextFieldCell" id="Dta-Xx-PQg" customClass="TextFieldControlCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TextFieldCell" id="Dta-Xx-PQg" customClass="TextFieldControlCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="961" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1076,7 +1076,7 @@
                                     <outlet property="titleLabel" destination="qFo-tw-1ix" id="JAo-ek-ZLh"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="RoundedTextFieldCell" id="N4E-8r-ew4" customClass="TextFieldControlCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="RoundedTextFieldCell" id="N4E-8r-ew4" customClass="TextFieldControlCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="961" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1129,7 +1129,7 @@
                                     <outlet property="titleLabel" destination="DNb-Rl-JVj" id="2YJ-VF-Zhx"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LineTextFieldCell" id="e93-eP-990" customClass="TextFieldControlCustomInputCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LineTextFieldCell" id="e93-eP-990" customClass="TextFieldControlCustomInputCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="1260" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1195,7 +1195,7 @@
                                     <outlet property="titleLabel" destination="tKc-Ht-mza" id="SIi-8y-BEB"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="BezelTextFieldCell" id="8ut-OK-HZV" customClass="TextFieldControlCustomInputCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="BezelTextFieldCell" id="8ut-OK-HZV" customClass="TextFieldControlCustomInputCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="1260" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1261,7 +1261,7 @@
                                     <outlet property="titleLabel" destination="uaX-OU-Igi" id="2v3-Po-Lgt"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SystemButtonCell" id="xkW-8D-F8s" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="SystemButtonCell" id="xkW-8D-F8s" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="1559" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1310,7 +1310,7 @@
                                     <outlet property="titleLabel" destination="G2i-Ox-JmM" id="DUi-hQ-KAI"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CustomButtonCell" id="HgL-qC-W9P" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CustomButtonCell" id="HgL-qC-W9P" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="1559" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1371,7 +1371,7 @@
                                     <outlet property="titleLabel" destination="JdO-yd-zbM" id="bpS-ty-Zkf"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DetailDisclosureButtonCell" id="BI1-da-OkD" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DetailDisclosureButtonCell" id="BI1-da-OkD" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="1858" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1424,7 +1424,7 @@
                                     <outlet property="titleLabel" destination="BQl-A9-LUI" id="vdT-EY-nWu"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AddContactButtonCell" id="e2f-7C-Saq" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AddContactButtonCell" id="e2f-7C-Saq" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="1858" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1524,7 +1524,7 @@
         <!--SpriteKit-->
         <scene sceneID="4yb-Yk-wBT">
             <objects>
-                <viewController id="Uqe-ND-9f1" customClass="SpriteKitViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Uqe-ND-9f1" customClass="SpriteKitViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="6OW-ll-rbH"/>
                         <viewControllerLayoutGuide type="bottom" id="Q2B-yi-kEc"/>
@@ -1593,18 +1593,18 @@
         <!--Alert View-->
         <scene sceneID="onv-b7-C5t">
             <objects>
-                <tableViewController id="gLA-bY-UPx" customClass="AlertViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="gLA-bY-UPx" customClass="AlertViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="50" sectionHeaderHeight="10" sectionFooterHeight="10" id="y5T-aE-26T">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="tintColor" red="0.18039215689999999" green="0.83529411760000005" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="AlertCell" id="9K8-gr-8GN" customClass="BasicCell" customModule="Revert" customModuleProvider="target">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="AlertCell" id="9K8-gr-8GN" customClass="BasicCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="114" width="600" height="50"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9K8-gr-8GN" id="sl6-ps-oHs">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="49"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Rz-Ft-pAH">
@@ -1646,7 +1646,7 @@
         <!--Picker View-->
         <scene sceneID="kpq-zZ-wqE">
             <objects>
-                <viewController id="T6q-5N-cqU" customClass="PickerViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="T6q-5N-cqU" customClass="PickerViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="gIX-0g-jah"/>
                         <viewControllerLayoutGuide type="bottom" id="YWa-cb-Hcr"/>
@@ -1658,7 +1658,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S74-Tx-UKU" userLabel="Container">
                                 <rect key="frame" x="0.0" y="64" width="600" height="536"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O4F-Ml-7dt" userLabel="Top Separator">
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O4F-Ml-7dt" userLabel="Top Separator">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="70"/>
                                         <color key="backgroundColor" red="0.94907671213150024" green="0.94865018129348755" blue="0.96507126092910767" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
@@ -1669,7 +1669,7 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="WkZ-u9-5Ws" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="height" constant="1" id="WkZ-u9-5Ws" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                             </view>
                                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6mg-54-6HQ" userLabel="Date Picker Container">
@@ -1695,7 +1695,7 @@
                                                 <rect key="frame" x="0.0" y="163" width="600" height="1"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="2XC-Xz-2UF" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="height" constant="1" id="2XC-Xz-2UF" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -1713,18 +1713,18 @@
                                             <constraint firstItem="iB8-oM-jRa" firstAttribute="top" secondItem="6mg-54-6HQ" secondAttribute="bottom" id="z2K-It-syj"/>
                                         </constraints>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lM2-2f-rOZ" userLabel="Middle Separator">
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lM2-2f-rOZ" userLabel="Middle Separator">
                                         <rect key="frame" x="0.0" y="234" width="600" height="69"/>
                                         <color key="backgroundColor" red="0.94907671213150024" green="0.94865018129348755" blue="0.96507126092910767" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FGZ-rT-zgu" userLabel="Lower Picker">
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FGZ-rT-zgu" userLabel="Lower Picker">
                                         <rect key="frame" x="0.0" y="302" width="600" height="164"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6VK-a0-0kP" userLabel="Picker Separator Top">
                                                 <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="NQH-7l-j8m" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="height" constant="1" id="NQH-7l-j8m" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                             </view>
                                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7oR-9d-yHN" userLabel="Picker Container">
@@ -1754,7 +1754,7 @@
                                                 <rect key="frame" x="0.0" y="163" width="600" height="1"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="HHj-nQ-wop" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                                    <constraint firstAttribute="height" constant="1" id="HHj-nQ-wop" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -1772,7 +1772,7 @@
                                             <constraint firstItem="7oR-9d-yHN" firstAttribute="top" secondItem="6VK-a0-0kP" secondAttribute="bottom" id="usz-Ew-fTa"/>
                                         </constraints>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XhP-p7-TTs" userLabel="Bottom Separator">
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XhP-p7-TTs" userLabel="Bottom Separator">
                                         <rect key="frame" x="0.0" y="466" width="600" height="70"/>
                                         <color key="backgroundColor" red="0.94907671213150024" green="0.94865018129348755" blue="0.96507126092910767" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
@@ -1828,19 +1828,19 @@
         <!--Views-->
         <scene sceneID="1T7-1I-ERk">
             <objects>
-                <collectionViewController id="QJe-hX-WOf" customClass="ControlsViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController id="QJe-hX-WOf" customClass="ControlsViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="interactive" dataMode="prototypes" id="nX5-EI-u4O">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94907671213150024" green="0.94865018129348755" blue="0.96507126092910767" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="NKL-MB-wn0" customClass="AdaptiveCollectionViewFlowLayout" customModule="Revert" customModuleProvider="target">
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="NKL-MB-wn0" customClass="AdaptiveCollectionViewFlowLayout" customModule="Revert_iOS" customModuleProvider="target">
                             <size key="itemSize" width="298" height="298"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
                             <inset key="sectionInset" minX="1" minY="0.0" maxX="1" maxY="35"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TextViewCell" id="oI0-lu-9AY" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TextViewCell" id="oI0-lu-9AY" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="64" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1889,7 +1889,7 @@
                                     <outlet property="titleLabel" destination="KFu-q2-Ysj" id="PJQ-bx-FBH"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ImageViewCell" id="p9e-dp-KgB" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ImageViewCell" id="p9e-dp-KgB" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="64" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1935,7 +1935,7 @@
                                     <outlet property="titleLabel" destination="1u0-zS-ka0" id="VPr-AL-C8b"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VolumeViewCell" id="Hxt-gh-lbA" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VolumeViewCell" id="Hxt-gh-lbA" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="363" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -1945,7 +1945,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6aM-FL-ocG">
                                             <rect key="frame" x="84" y="123" width="130" height="53"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-Bd-8eQ" customClass="VolumeView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-Bd-8eQ" customClass="VolumeView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="31"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -1982,7 +1982,7 @@
                                     <outlet property="titleLabel" destination="Y0U-4X-ubM" id="DAo-ah-iaP"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ProgressViewCell" id="I0A-fB-ZHW" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ProgressViewCell" id="I0A-fB-ZHW" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="363" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -2027,7 +2027,7 @@
                                     <outlet property="titleLabel" destination="p6c-xT-UEd" id="dgn-ZO-2qe"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LabelCell" id="VeB-xG-1vG" customClass="CollectionViewCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LabelCell" id="VeB-xG-1vG" customClass="CollectionViewCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="662" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -2098,7 +2098,7 @@
         <!--Web View Controller-->
         <scene sceneID="hhK-5P-fIh">
             <objects>
-                <viewController id="zbC-XF-QPg" customClass="WebViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="zbC-XF-QPg" customClass="WebViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="RT8-lc-X3a"/>
                         <viewControllerLayoutGuide type="bottom" id="WrG-Rz-40G"/>
@@ -2139,7 +2139,7 @@
         <!--Open GL-->
         <scene sceneID="mtZ-YC-uYA">
             <objects>
-                <glkViewController preferredFramesPerSecond="60" id="GD0-Eo-RNg" customClass="OpenGLViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <glkViewController preferredFramesPerSecond="60" id="GD0-Eo-RNg" customClass="OpenGLViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="zaV-f3-sf7"/>
                         <viewControllerLayoutGuide type="bottom" id="CLt-kN-smg"/>
@@ -2167,7 +2167,7 @@
         <!--Stack View-->
         <scene sceneID="IpS-42-uzs">
             <objects>
-                <viewController id="Zpy-1F-xWH" customClass="StackViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Zpy-1F-xWH" customClass="StackViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="eSr-1k-dch"/>
                         <viewControllerLayoutGuide type="bottom" id="TBh-Ck-rMw"/>
@@ -2195,7 +2195,7 @@
         <!--Safari View Controller-->
         <scene sceneID="nvz-qa-Yob">
             <objects>
-                <viewController id="8wk-Ae-Mic" customClass="SafariViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="8wk-Ae-Mic" customClass="SafariViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="VHq-HQ-xAf"/>
                         <viewControllerLayoutGuide type="bottom" id="NiO-MZ-vhL"/>
@@ -2311,7 +2311,7 @@
         <!--Revert-->
         <scene sceneID="Qzv-sJ-S6S">
             <objects>
-                <tableViewController clearsSelectionOnViewWillAppear="NO" id="Utk-Aw-BAf" customClass="HomeViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController clearsSelectionOnViewWillAppear="NO" id="Utk-Aw-BAf" customClass="HomeViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="52" sectionHeaderHeight="10" sectionFooterHeight="10" id="BmS-bf-dbI">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2385,7 +2385,7 @@
         <!--Auto Layout-->
         <scene sceneID="K1c-e7-lit">
             <objects>
-                <viewController id="Ae9-a4-dBl" customClass="RevertViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Ae9-a4-dBl" customClass="RevertViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Kkf-X6-llX"/>
                         <viewControllerLayoutGuide type="bottom" id="7Xj-bo-Bd6"/>
@@ -2545,7 +2545,7 @@
         <!--Auto Layout Margins-->
         <scene sceneID="6ot-VI-ZcG">
             <objects>
-                <viewController id="AT1-f1-sr1" customClass="AutoLayoutMarginsViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="AT1-f1-sr1" customClass="AutoLayoutMarginsViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="E4Y-ED-xsm"/>
                         <viewControllerLayoutGuide type="bottom" id="yQj-bT-zyr"/>
@@ -2557,7 +2557,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q3k-fA-4GD" userLabel="Container">
                                 <rect key="frame" x="0.0" y="64" width="600" height="490"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="800" verticalCompressionResistancePriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="ml3-CY-mgV" userLabel="Center View" customClass="CustomIntrinsicContentSizeView" customModule="Revert" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="800" verticalCompressionResistancePriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="ml3-CY-mgV" userLabel="Center View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_iOS" customModuleProvider="target">
                                         <rect key="frame" x="260" y="205" width="80" height="80"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ebx-85-dhz">
@@ -2586,7 +2586,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ou0-qC-1Pb" userLabel="Right View" customClass="CustomIntrinsicContentSizeView" customModule="Revert" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ou0-qC-1Pb" userLabel="Right View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_iOS" customModuleProvider="target">
                                         <rect key="frame" x="364" y="197" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.9956403374671936" green="0.68156266212463379" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Right View"/>
@@ -2599,7 +2599,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qSc-hW-wrq" userLabel="Bottom View" customClass="CustomIntrinsicContentSizeView" customModule="Revert" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qSc-hW-wrq" userLabel="Bottom View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_iOS" customModuleProvider="target">
                                         <rect key="frame" x="268" y="309" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.18039215689999999" green="0.83529411760000005" blue="0.76470588240000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Bottom View"/>
@@ -2612,7 +2612,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n6U-F2-dD7" userLabel="Left View" customClass="CustomIntrinsicContentSizeView" customModule="Revert" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n6U-F2-dD7" userLabel="Left View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_iOS" customModuleProvider="target">
                                         <rect key="frame" x="156" y="213" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.81012684106826782" green="0.32538783550262451" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Left View"/>
@@ -2625,7 +2625,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7V2-f5-C5V" userLabel="Top View" customClass="CustomIntrinsicContentSizeView" customModule="Revert" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7V2-f5-C5V" userLabel="Top View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_iOS" customModuleProvider="target">
                                         <rect key="frame" x="252" y="101" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.42200243473052979" green="0.76358240842819214" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Top View"/>
@@ -2645,7 +2645,7 @@
                                     <constraint firstAttribute="centerX" secondItem="ml3-CY-mgV" secondAttribute="centerX" id="S1p-mL-VeN"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="790-cb-XJk" customClass="SliderMarginsAdjustingView" customModule="Revert" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="790-cb-XJk" customClass="SliderMarginsAdjustingView" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="20" y="554" width="560" height="46"/>
                                 <subviews>
                                     <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="rfO-2Q-Zto">
@@ -2737,7 +2737,7 @@
         <!--Auto Layout Alignments-->
         <scene sceneID="ET9-ag-1Ke">
             <objects>
-                <viewController id="CrR-c1-A5E" customClass="RevertViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="CrR-c1-A5E" customClass="RevertViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="nhe-Iu-BvR"/>
                         <viewControllerLayoutGuide type="bottom" id="p6M-it-JEr"/>
@@ -2783,7 +2783,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZXn-Yf-pFc" userLabel="Bottom Left View">
                                 <rect key="frame" x="16" y="448" width="393" height="100"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fTZ-r7-88x" customClass="AlignmentInsetView" customModule="Revert" customModuleProvider="target">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fTZ-r7-88x" customClass="AlignmentInsetView" customModule="Revert_iOS" customModuleProvider="target">
                                         <rect key="frame" x="171" y="25" width="50" height="50"/>
                                         <color key="backgroundColor" red="1" green="0.030603691935539246" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
@@ -2857,37 +2857,37 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Baseline Aligned" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qz0-mi-y6s">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Baseline Aligned" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qz0-mi-y6s">
                                 <rect key="frame" x="124" y="341" width="127" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F8s-Kl-vgc">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F8s-Kl-vgc">
                                 <rect key="frame" x="259" y="346" width="37" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vertically Centered" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dfy-18-kzU">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Vertically Centered" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dfy-18-kzU">
                                 <rect key="frame" x="124" y="370" width="146" height="20"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WYW-gA-DCz">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WYW-gA-DCz">
                                 <rect key="frame" x="278" y="373" width="37" height="14"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Horizontally Centered" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eST-6h-VKt">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Horizontally Centered" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eST-6h-VKt">
                                 <rect key="frame" x="124" y="398" width="167" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uKV-M6-fjO">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uKV-M6-fjO">
                                 <rect key="frame" x="189" y="427" width="37" height="14"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -2990,7 +2990,7 @@
         <!--Info-->
         <scene sceneID="41J-PG-blc">
             <objects>
-                <viewController id="4Px-36-ahp" customClass="InfoViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="4Px-36-ahp" customClass="InfoViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="mvh-Up-AnA"/>
                         <viewControllerLayoutGuide type="bottom" id="6Rj-SH-rTM"/>
@@ -3033,7 +3033,7 @@
                                         <rect key="frame" x="0.0" y="52" width="600" height="1"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="1Cw-ik-Jaw" customClass="HairlineConstraint" customModule="Revert" customModuleProvider="target"/>
+                                            <constraint firstAttribute="height" constant="1" id="1Cw-ik-Jaw" customClass="HairlineConstraint" customModule="Revert_iOS" customModuleProvider="target"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -3088,7 +3088,7 @@
         <!--Stress Test-->
         <scene sceneID="tKJ-hz-Uwn">
             <objects>
-                <collectionViewController id="gwo-YA-zzL" customClass="StressTestViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController id="gwo-YA-zzL" customClass="StressTestViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="VHO-V4-ra3">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -3107,7 +3107,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ncx-lw-kCg" customClass="DeepView" customModule="Revert" customModuleProvider="target">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ncx-lw-kCg" customClass="DeepView" customModule="Revert_iOS" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                             <color key="backgroundColor" red="0.15684163570404053" green="0.15687522292137146" blue="0.15683692693710327" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </view>
@@ -3142,7 +3142,7 @@
         <!--Autoresizing Masks-->
         <scene sceneID="xgI-cv-kN2">
             <objects>
-                <viewController id="6aA-pS-GGk" customClass="AutoResizingMaskViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="6aA-pS-GGk" customClass="AutoResizingMaskViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="nCn-Qh-UB2"/>
                         <viewControllerLayoutGuide type="bottom" id="JGO-5Q-n72"/>
@@ -3206,7 +3206,7 @@
         <!--Transform Views-->
         <scene sceneID="XBp-RH-0ab">
             <objects>
-                <viewController id="34u-gx-HPd" customClass="TransformViewsViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="34u-gx-HPd" customClass="TransformViewsViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="cqh-pz-e8P"/>
                         <viewControllerLayoutGuide type="bottom" id="bW3-q0-eBp"/>
@@ -3227,7 +3227,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOM-vP-6mx" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOM-vP-6mx" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3242,7 +3242,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nMF-zP-KRW" userLabel="Transformed View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nMF-zP-KRW" userLabel="Transformed View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Translated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="prt-Ma-bjP">
@@ -3292,7 +3292,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iuj-rw-ZVs" userLabel="Original Scale View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iuj-rw-ZVs" userLabel="Original Scale View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="67" width="500" height="50"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3307,7 +3307,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ck4-Sp-cNQ" userLabel="Scaled View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ck4-Sp-cNQ" userLabel="Scaled View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="67" width="500" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scaled Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.10000000000000001" translatesAutoresizingMaskIntoConstraints="NO" id="7Yr-Cp-wdl">
@@ -3357,7 +3357,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ptE-TK-GaT" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ptE-TK-GaT" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3372,7 +3372,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t1Y-oo-oIk" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t1Y-oo-oIk" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="scK-ju-dcJ">
@@ -3483,7 +3483,7 @@
         <!--Super Deep-->
         <scene sceneID="ndd-MQ-fT5">
             <objects>
-                <viewController id="cKD-ZG-JZw" customClass="RevertViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="cKD-ZG-JZw" customClass="RevertViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="lIb-EX-hHx"/>
                         <viewControllerLayoutGuide type="bottom" id="tf9-FK-G90"/>
@@ -3492,7 +3492,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gFt-rV-fjz" customClass="DeepView" customModule="Revert" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gFt-rV-fjz" customClass="DeepView" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="64" width="600" height="536"/>
                                 <color key="backgroundColor" red="0.15684163570404053" green="0.15687522292137146" blue="0.15683692693710327" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
@@ -3542,7 +3542,7 @@
         <!--Transform Layers-->
         <scene sceneID="dGn-fW-arV">
             <objects>
-                <viewController id="emN-Y6-Z2K" customClass="TransformLayersViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="emN-Y6-Z2K" customClass="TransformLayersViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="4nO-BS-O9H"/>
                         <viewControllerLayoutGuide type="bottom" id="coC-tA-1cY"/>
@@ -3563,7 +3563,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W99-4Q-Ptm" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W99-4Q-Ptm" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3578,7 +3578,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3I4-iT-AYg" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3I4-iT-AYg" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VXT-xi-rJl">
@@ -3628,7 +3628,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bqp-d2-Lob" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bqp-d2-Lob" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3643,7 +3643,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QNk-Sj-PpA" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QNk-Sj-PpA" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TRt-zl-Ybn">
@@ -3692,7 +3692,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C9n-gr-EkR" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C9n-gr-EkR" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3707,7 +3707,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nBL-0A-Pri" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nBL-0A-Pri" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mo8-cB-Obc">
@@ -3756,7 +3756,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lPy-pR-OcN" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lPy-pR-OcN" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3771,7 +3771,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HFw-3s-Dae" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HFw-3s-Dae" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="50" y="57" width="500" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ryr-Hg-ZQb">
@@ -3910,7 +3910,7 @@
         <!--Bounds Change & Anchor Point-->
         <scene sceneID="JEK-0m-egP">
             <objects>
-                <viewController id="NyI-qR-3G7" customClass="AnchorPointBoundsChangeViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="NyI-qR-3G7" customClass="AnchorPointBoundsChangeViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="w2P-Lr-b90"/>
                         <viewControllerLayoutGuide type="bottom" id="iyF-K3-nY4"/>
@@ -3931,7 +3931,7 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qjB-yV-R09" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qjB-yV-R09" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="250" y="57" width="100" height="100"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3947,7 +3947,7 @@
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jcn-NB-yCf" userLabel="Transform View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jcn-NB-yCf" userLabel="Transform View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="250" y="57" width="100" height="100"/>
                                                 <color key="backgroundColor" red="0.81829309459999999" green="0.28785437349999998" blue="1" alpha="0.85098039219999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
@@ -3984,10 +3984,10 @@
                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rc9-Nd-PMc" userLabel="Bounds Change View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rc9-Nd-PMc" userLabel="Bounds Change View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="250" y="57" width="100" height="100"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z6N-Fy-VL2" userLabel="Transform View" customClass="HairlineBorderView" customModule="Revert" customModuleProvider="target">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z6N-Fy-VL2" userLabel="Transform View" customClass="HairlineBorderView" customModule="Revert_iOS" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                                         <color key="backgroundColor" red="0.81829309459999999" green="0.28785437349999998" blue="1" alpha="0.85098039219999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <userDefinedRuntimeAttributes>
@@ -4095,7 +4095,7 @@
         <!--Not Serializable-->
         <scene sceneID="EBD-yQ-eaG">
             <objects>
-                <viewController id="tHf-fw-MlU" customClass="NonSerializableViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="tHf-fw-MlU" customClass="NonSerializableViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="V5g-gb-I8q"/>
                         <viewControllerLayoutGuide type="bottom" id="V43-2n-Xvu"/>
@@ -4213,19 +4213,19 @@
         <!--Layer Properties-->
         <scene sceneID="uvP-f3-Wui">
             <objects>
-                <collectionViewController id="sz2-FY-SQT" customClass="ControlsViewController" customModule="Revert" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController id="sz2-FY-SQT" customClass="ControlsViewController" customModule="Revert_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="interactive" dataMode="prototypes" id="pIC-Y7-GIB">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="r7i-hj-Imh" customClass="AdaptiveCollectionViewFlowLayout" customModule="Revert" customModuleProvider="target">
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="1" minimumInteritemSpacing="1" id="r7i-hj-Imh" customClass="AdaptiveCollectionViewFlowLayout" customModule="Revert_iOS" customModuleProvider="target">
                             <size key="itemSize" width="298" height="298"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
                             <inset key="sectionInset" minX="1" minY="0.0" maxX="1" maxY="35"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TextLayerCell" id="Fya-ne-N0M" customClass="CATextLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TextLayerCell" id="Fya-ne-N0M" customClass="CATextLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="64" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4235,7 +4235,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qCc-ht-ivH">
                                             <rect key="frame" x="84" y="84" width="130" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j0I-0T-ibi" customClass="CATextLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j0I-0T-ibi" customClass="CATextLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4276,7 +4276,7 @@
                                     <outlet property="titleLabel" destination="LWr-yM-owq" id="Vy8-fn-G50"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="EmitterLayerCell" id="rsU-Mc-V1F" customClass="CAEmitterLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="EmitterLayerCell" id="rsU-Mc-V1F" customClass="CAEmitterLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="64" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4286,7 +4286,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d9g-zX-7wv">
                                             <rect key="frame" x="84" y="84" width="130" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TPD-8S-yME" customClass="CAEmitterLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TPD-8S-yME" customClass="CAEmitterLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4327,7 +4327,7 @@
                                     <outlet property="titleLabel" destination="lSK-G4-lkD" id="0cb-6u-dTe"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ShapeLayerCell" id="TrP-g7-0OG" customClass="CAShapeLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ShapeLayerCell" id="TrP-g7-0OG" customClass="CAShapeLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="363" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4337,7 +4337,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R1u-90-vgW">
                                             <rect key="frame" x="84" y="84" width="130" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kKm-jM-3tL" customClass="CAShapeLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kKm-jM-3tL" customClass="CAShapeLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4378,7 +4378,7 @@
                                     <outlet property="titleLabel" destination="1e2-39-EsZ" id="GaO-Oa-AsL"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ScrollLayerCell" id="Eb1-op-wWO" customClass="CAScrollLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ScrollLayerCell" id="Eb1-op-wWO" customClass="CAScrollLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="363" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4388,7 +4388,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eab-3q-B81">
                                             <rect key="frame" x="84" y="84" width="130" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5sr-T0-NYI" customClass="CAScrollLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5sr-T0-NYI" customClass="CAScrollLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4429,7 +4429,7 @@
                                     <outlet property="titleLabel" destination="3NR-Li-Boc" id="UFg-De-dHd"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TiledLayerCell" id="SfN-Ln-8Qo" customClass="CATiledLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TiledLayerCell" id="SfN-Ln-8Qo" customClass="CATiledLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="662" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4439,7 +4439,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dy1-Ri-IN2">
                                             <rect key="frame" x="84" y="84" width="130" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOl-vR-iRN" customClass="CATiledLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOl-vR-iRN" customClass="CATiledLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4480,7 +4480,7 @@
                                     <outlet property="titleLabel" destination="Ght-KC-iw6" id="XjK-jc-65P"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="GradientLayerCell" id="lgk-gX-L9A" customClass="CAGradientLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="GradientLayerCell" id="lgk-gX-L9A" customClass="CAGradientLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="662" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4490,7 +4490,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P1u-Xy-Ezd">
                                             <rect key="frame" x="84" y="84" width="130" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x4b-qn-XFZ" customClass="CAGradientLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x4b-qn-XFZ" customClass="CAGradientLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4531,7 +4531,7 @@
                                     <outlet property="titleLabel" destination="MeM-sd-5Vm" id="iLl-si-66f"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ReplicatorLayerCell" id="toT-IZ-yEO" customClass="CAReplicatorLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ReplicatorLayerCell" id="toT-IZ-yEO" customClass="CAReplicatorLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="1" y="961" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4541,7 +4541,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bww-Ka-Xbv">
                                             <rect key="frame" x="82" y="84" width="134" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U9t-hX-9ja" customClass="CAReplicatorLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U9t-hX-9ja" customClass="CAReplicatorLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="2" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4581,7 +4581,7 @@
                                     <outlet property="titleLabel" destination="xej-lp-Nvb" id="pHn-IW-zXa"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AEGLayerCell" id="3fM-Ms-N9K" customClass="CAEAGLLayerCell" customModule="Revert" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AEGLayerCell" id="3fM-Ms-N9K" customClass="CAEAGLLayerCell" customModule="Revert_iOS" customModuleProvider="target">
                                 <rect key="frame" x="301" y="961" width="298" height="298"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -4591,7 +4591,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pax-2t-c5g">
                                             <rect key="frame" x="84" y="84" width="130" height="130"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vyJ-Cz-PkQ" customClass="CAEAGLLayerView" customModule="Revert" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vyJ-Cz-PkQ" customClass="CAEAGLLayerView" customModule="Revert_iOS" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="130" height="102"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -4705,7 +4705,7 @@
         <image name="x-wing" width="45" height="16"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="U7X-9a-vKX"/>
+        <segue reference="gSb-RG-pTo"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.21786168217658997" green="0.67291539907455444" blue="0.94411402940750122" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>

--- a/Revert/Sources/InfoBuilder.swift
+++ b/Revert/Sources/InfoBuilder.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import Foundation
 

--- a/Revert/Sources/KeyboardHandler.swift
+++ b/Revert/Sources/KeyboardHandler.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import UIKit
 

--- a/Revert/Sources/VolumeView.swift
+++ b/Revert/Sources/VolumeView.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import UIKit
 import MediaPlayer

--- a/Shared/Resources/Data/HomeItems_iOS.plist
+++ b/Shared/Resources/Data/HomeItems_iOS.plist
@@ -141,55 +141,54 @@
 				<key>infoFilename</key>
 				<string>open_gl</string>
 			</dict>
-            <dict>
-                <key>title</key>
-                <string>Web View</string>
-                <key>iconName</key>
-                <string>icon_WebView</string>
-                <key>segueIdentifier</key>
-                <string>ShowWebViewControllerSegue</string>
-                <key>infoFilename</key>
-                <string>web_views</string>
-            </dict>
-            
+			<dict>
+				<key>title</key>
+				<string>Web View</string>
+				<key>iconName</key>
+				<string>icon_WebView</string>
+				<key>segueIdentifier</key>
+				<string>ShowWebViewControllerSegue</string>
+				<key>infoFilename</key>
+				<string>web_views</string>
+			</dict>
 		</array>
 	</dict>
-    <dict>
-        <key>rows</key>
-        <array>
-            <dict>
-                <key>title</key>
-                <string>Safari View Controller</string>
-                <key>iconName</key>
-                <string>icon_SFSafariViewController</string>
-                <key>segueIdentifier</key>
-                <string>ShowSFSafariViewControllerSegue</string>
-                <key>infoFilename</key>
-                <string>sf_safari_view_controller</string>
-                <key>requiredClassName</key>
-                <string>SFSafariViewController</string>
-                <key>isPush</key>
-                <true/>
-            </dict>
-        </array>
-    </dict>
-    <dict>
-        <key>rows</key>
-        <array>
-            <dict>
-                <key>title</key>
-                <string>Modal View</string>
-                <key>iconName</key>
-                <string>icon_Modal</string>
-                <key>segueIdentifier</key>
-                <string>ShowModalViewController</string>
-                <key>isPush</key>
-                <false/>
-                <key>infoFilename</key>
-                <string>modal_view</string>
-            </dict>
-        </array>
-    </dict>
+	<dict>
+		<key>rows</key>
+		<array>
+			<dict>
+				<key>title</key>
+				<string>Safari View Controller</string>
+				<key>iconName</key>
+				<string>icon_SFSafariViewController</string>
+				<key>segueIdentifier</key>
+				<string>ShowSFSafariViewControllerSegue</string>
+				<key>infoFilename</key>
+				<string>sf_safari_view_controller</string>
+				<key>requiredClassName</key>
+				<string>SFSafariViewController</string>
+				<key>isPush</key>
+				<true/>
+			</dict>
+		</array>
+	</dict>
+	<dict>
+		<key>rows</key>
+		<array>
+			<dict>
+				<key>title</key>
+				<string>Modal View</string>
+				<key>iconName</key>
+				<string>icon_Modal</string>
+				<key>segueIdentifier</key>
+				<string>ShowModalViewController</string>
+				<key>isPush</key>
+				<false/>
+				<key>infoFilename</key>
+				<string>modal_view</string>
+			</dict>
+		</array>
+	</dict>
 	<dict>
 		<key>rows</key>
 		<array>

--- a/Shared/Sources/CountriesViewController.swift
+++ b/Shared/Sources/CountriesViewController.swift
@@ -1,4 +1,4 @@
- //
+//
 //  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import UIKit

--- a/Shared/Sources/CustomIntrinsicContentSizeView.swift
+++ b/Shared/Sources/CustomIntrinsicContentSizeView.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import UIKit
 

--- a/Shared/Sources/HairlineConstraint.swift
+++ b/Shared/Sources/HairlineConstraint.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import UIKit
 

--- a/Shared/Sources/Revert-Bridging-Header.h
+++ b/Shared/Sources/Revert-Bridging-Header.h
@@ -1,5 +1,4 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 #import "Cube.h"

--- a/Shared/Sources/RevertItems.swift
+++ b/Shared/Sources/RevertItems.swift
@@ -1,6 +1,5 @@
 //
 //  Copyright © 2015 Itty Bitty Apps. All rights reserved.
-//
 
 import Foundation
 

--- a/Shared/Sources/SplitViewControllerDelegate.swift
+++ b/Shared/Sources/SplitViewControllerDelegate.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import UIKit
 

--- a/Shared/Sources/StackViewController.swift
+++ b/Shared/Sources/StackViewController.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 @available(iOS 9.0, *)
-class StackViewController: RevertViewController {
+final class StackViewController: RevertViewController {
   override func loadView() {
     let nib = NSBundle.mainBundle().loadNibNamed("StackView", owner: self, options: nil)
     guard let view = nib.first as? UIView else {

--- a/Shared/Sources/Static.swift
+++ b/Shared/Sources/Static.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 import Foundation
 import MapKit

--- a/Shared/Sources/StoryboardIdentifiers.swift
+++ b/Shared/Sources/StoryboardIdentifiers.swift
@@ -1,6 +1,5 @@
 //
-//  Copyright (c) 2015 Itty Bitty Apps. All rights reserved.
-//
+//  Copyright © 2015 Itty Bitty Apps. All rights reserved.
 
 struct Storyboards {
   struct Cell {


### PR DESCRIPTION
This PR does a few cleanup on the iOS side of things:
- Adds a missing `final` qualifier on `StackViewController`.
- Sets the copyright headers to `2016`, and fixes the formatting - lets try to be consistent.
- Moves `strings.dict` in the shared part of the folder, attach it to the iOS target.
- Auto update of iOS main.storyboard now that the module has changed.
- Fixes formatting in `HomeItems_iOS.plist`. If modified from an external editor please open it back in Xcode so that the formatting matches across the project.
