### PR TITLE
Dark style for tvOS

### DIFF
--- a/Revert-tvOS/Base.lproj/Main.storyboard
+++ b/Revert-tvOS/Base.lproj/Main.storyboard
@@ -1678,6 +1678,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOM-vP-6mx" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1737,6 +1740,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iuj-rw-ZVs" userLabel="Original Scale View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1796,6 +1802,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ptE-TK-GaT" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Revert-tvOS/Base.lproj/Main.storyboard
+++ b/Revert-tvOS/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="634" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" misplaced="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeCell" id="JSQ-A6-fCK">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeCell" id="JSQ-A6-fCK">
                                 <rect key="frame" x="0.0" y="185" width="634" height="66"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="JSQ-A6-fCK" id="gEB-GB-Jeq">
@@ -414,6 +414,9 @@
                                                         <real key="value" value="1"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="blY-Pd-GBR" userLabel="Top 1px High View">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -425,6 +428,9 @@
                                                         <real key="value" value="1"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="piu-ME-qW0" userLabel="Left 1px Width View">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -436,6 +442,9 @@
                                                         <real key="value" value="1"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ADL-Xh-nuv" userLabel="Right 1px Width View">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -447,6 +456,9 @@
                                                         <real key="value" value="1"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nLX-bX-2HL" userLabel="Top View">
                                                 <color key="backgroundColor" red="0.16429150104522705" green="0.25510802865028381" blue="0.99832439422607422" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Revert-tvOS/Base.lproj/Main.storyboard
+++ b/Revert-tvOS/Base.lproj/Main.storyboard
@@ -2197,6 +2197,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qjB-yV-R09" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2245,6 +2248,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rc9-Nd-PMc" userLabel="Bounds Change View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <subviews>

--- a/Revert-tvOS/Base.lproj/Main.storyboard
+++ b/Revert-tvOS/Base.lproj/Main.storyboard
@@ -1340,11 +1340,17 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
+                                <variation key="userInterfaceStyle=dark">
+                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This StackView has NaN as spacing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZYW-2r-xVj">
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
+                                <variation key="userInterfaceStyle=dark">
+                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trailing Space constant = CGFloat.min on this label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tVU-gF-R1R">
                                 <constraints>
@@ -1353,6 +1359,9 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
+                                <variation key="userInterfaceStyle=dark">
+                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                </variation>
                             </label>
                         </subviews>
                         <constraints>

--- a/Revert-tvOS/Base.lproj/Main.storyboard
+++ b/Revert-tvOS/Base.lproj/Main.storyboard
@@ -1906,6 +1906,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W99-4Q-Ptm" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1965,6 +1968,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bqp-d2-Lob" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2023,6 +2029,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C9n-gr-EkR" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2081,6 +2090,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="userInterfaceStyle=dark">
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                </variation>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lPy-pR-OcN" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Revert-tvOS/Base.lproj/Main.storyboard
+++ b/Revert-tvOS/Base.lproj/Main.storyboard
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="11535.1" systemVersion="16A323" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="Kps-Wr-dkW">
-    <device id="appleTV" orientation="landscape">
-        <adaptation id="light"/>
-    </device>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Kps-Wr-dkW">
     <dependencies>
         <deployment identifier="tvOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11523"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -21,11 +18,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="634" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeCell" id="JSQ-A6-fCK">
-                                <rect key="frame" x="0.0" y="40" width="634" height="66"/>
+                            <tableViewCell contentMode="scaleToFill" misplaced="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeCell" id="JSQ-A6-fCK">
+                                <rect key="frame" x="0.0" y="185" width="634" height="66"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="JSQ-A6-fCK" id="gEB-GB-Jeq">
-                                    <rect key="frame" x="0.0" y="0.0" width="618" height="66"/>
+                                    <frame key="frameInset" width="618" height="66"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -108,13 +105,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="banner_WhatsNew" translatesAutoresizingMaskIntoConstraints="NO" id="qoL-Hj-9Hw">
-                                <rect key="frame" x="0.0" y="0.0" width="1920" height="600"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="600" id="oYg-vV-iT3"/>
                                 </constraints>
                             </imageView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="cro-LW-isO">
-                                <rect key="frame" x="0.0" y="700" width="1920" height="380"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="60" minimumInteritemSpacing="100" id="L04-pa-tnH">
                                     <size key="itemSize" width="300" height="300"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -129,11 +124,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="300" height="240"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PYi-Mh-E7a">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="140"/>
-                                                </imageView>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PYi-Mh-E7a"/>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BJi-57-iFw">
-                                                    <rect key="frame" x="129" y="180" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -192,21 +184,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="1285" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" misplaced="YES" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="TableViewControllerCell" id="ZGj-pT-j6R" customClass="BasicCell" customModule="Revert_tvOS" customModuleProvider="target">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="TableViewControllerCell" id="ZGj-pT-j6R" customClass="BasicCell" customModule="Revert_tvOS" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="40" width="1285" height="66"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZGj-pT-j6R" id="8Fb-SC-xXg">
-                                    <rect key="frame" x="0.0" y="0.0" width="1196" height="66"/>
+                                    <frame key="frameInset" width="1196" height="66"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xMi-ka-a3Z">
-                                            <rect key="frame" x="15" y="16" width="58" height="35"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FyQ-Dl-hFo">
-                                            <rect key="frame" x="1124" y="16" width="73" height="35"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" id="upD-5Q-jwC"/>
                                             </constraints>
@@ -254,10 +244,8 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bxo-2G-eMc" customClass="RevertFocusableScrollView" customModule="Revert_tvOS">
-                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" image="reveal_pretty" translatesAutoresizingMaskIntoConstraints="NO" id="zEC-Nq-c8u">
-                                        <rect key="frame" x="0.0" y="0.0" width="2160" height="2160"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="zEC-Nq-c8u" secondAttribute="height" multiplier="1:1" id="3Kl-qz-Mgs"/>
                                         </constraints>
@@ -318,11 +306,10 @@
                                 <rect key="frame" x="0.0" y="40" width="1144" height="66"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZHJ-mv-O1d" id="yhS-pc-0F4">
-                                    <rect key="frame" x="0.0" y="0.0" width="1904" height="66"/>
+                                    <frame key="frameInset" width="1904" height="66"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hjr-J3-SwP">
-                                            <rect key="frame" x="23" y="23" width="34" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -364,7 +351,6 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" rotateEnabled="NO" pitchEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3l0-P5-zsv">
-                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                 <connections>
                                     <outlet property="delegate" destination="Dak-gW-7g8" id="z67-aU-01I"/>
                                 </connections>
@@ -399,13 +385,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qt1-pP-YK1">
-                                <rect key="frame" x="90" y="60" width="1740" height="960"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eWE-n9-7js" userLabel="Samples">
-                                        <rect key="frame" x="410" y="20" width="920" height="920"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OqT-sa-tWo" userLabel="Center View">
-                                                <rect key="frame" x="205" y="205" width="510" height="510"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -414,7 +397,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MPU-9q-W9e" userLabel="Bottom View">
-                                                <rect key="frame" x="27" y="723" width="866" height="170"/>
                                                 <color key="backgroundColor" red="0.34494423866271973" green="0.70911610126495361" blue="0.99616682529449463" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -423,7 +405,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gCn-da-VZE" userLabel="Bottom 1px High View">
-                                                <rect key="frame" x="27" y="901" width="866" height="1"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Gn3-E9-Vej" customClass="HairlineConstraint" customModule="Revert_tvOS" customModuleProvider="target"/>
@@ -435,7 +416,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="blY-Pd-GBR" userLabel="Top 1px High View">
-                                                <rect key="frame" x="27" y="18" width="866" height="1"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="pvI-5g-07b" customClass="HairlineConstraint" customModule="Revert_tvOS" customModuleProvider="target"/>
@@ -447,7 +427,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="piu-ME-qW0" userLabel="Left 1px Width View">
-                                                <rect key="frame" x="18" y="27" width="1" height="866"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="1" id="y6P-DN-ylq" customClass="HairlineConstraint" customModule="Revert_tvOS" customModuleProvider="target"/>
@@ -459,7 +438,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ADL-Xh-nuv" userLabel="Right 1px Width View">
-                                                <rect key="frame" x="901" y="27" width="1" height="866"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="1" id="I18-iO-8UK" customClass="HairlineConstraint" customModule="Revert_tvOS" customModuleProvider="target"/>
@@ -471,7 +449,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nLX-bX-2HL" userLabel="Top View">
-                                                <rect key="frame" x="27" y="27" width="866" height="170"/>
                                                 <color key="backgroundColor" red="0.16429150104522705" green="0.25510802865028381" blue="0.99832439422607422" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -480,7 +457,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uRZ-Wf-s5d" userLabel="Right View">
-                                                <rect key="frame" x="723" y="205" width="170" height="510"/>
                                                 <color key="backgroundColor" red="0.75690394639968872" green="0.17739748954772949" blue="0.99884581565856934" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -489,7 +465,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Js-N1-HDr" userLabel="Left View">
-                                                <rect key="frame" x="27" y="205" width="170" height="510"/>
                                                 <color key="backgroundColor" red="0.99141454696655273" green="0.60372090339660645" blue="0.034282982349395752" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -583,10 +558,8 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Eow-WP-D5J">
-                                <rect key="frame" x="90" y="60" width="1740" height="916"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yPk-JU-Yv3">
-                                        <rect key="frame" x="20" y="20" width="1700" height="25"/>
                                         <color key="backgroundColor" red="0.34494423866271973" green="0.70911610126495361" blue="0.99616682529449463" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="SvM-AP-Sgc"/>
@@ -598,7 +571,6 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ogi-js-vJS">
-                                        <rect key="frame" x="20" y="871" width="1700" height="25"/>
                                         <color key="backgroundColor" red="0.34494423866271973" green="0.70911610126495361" blue="0.99616682529449463" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="N1c-jK-Z64"/>
@@ -610,10 +582,8 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QI8-18-dJq">
-                                        <rect key="frame" x="20" y="53" width="810" height="810"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Etd-pA-VYO">
-                                                <rect key="frame" x="203" y="203" width="405" height="405"/>
                                                 <color key="backgroundColor" red="0.34494423866271973" green="0.70911610126495361" blue="0.99616682529449463" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Etd-pA-VYO" secondAttribute="height" multiplier="1:1" id="hLT-gS-ifg"/>
@@ -639,10 +609,8 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6eq-yE-ba2">
-                                        <rect key="frame" x="910" y="53" width="810" height="810"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5lq-dQ-ALK">
-                                                <rect key="frame" x="203" y="203" width="405" height="405"/>
                                                 <color key="backgroundColor" red="0.34494423866271973" green="0.70911610126495361" blue="0.99616682529449463" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -712,7 +680,6 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F0i-XL-vZn" userLabel="Top View">
-                                <rect key="frame" x="90" y="60" width="960" height="500"/>
                                 <color key="backgroundColor" red="0.99141454696655273" green="0.60372090339660645" blue="0.034282982349395752" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="960" id="AaF-I3-6db"/>
@@ -724,7 +691,6 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QVr-RD-GnT" userLabel="Middle Left View">
-                                <rect key="frame" x="90" y="568" width="60" height="300"/>
                                 <color key="backgroundColor" red="0.34494423866271973" green="0.70911610126495361" blue="0.99616682529449463" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="60" id="XxP-Tm-cOI"/>
@@ -737,7 +703,6 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OEj-Na-HCf" userLabel="Middle Right View">
-                                <rect key="frame" x="158" y="568" width="892" height="300"/>
                                 <color key="backgroundColor" red="0.17830546200275421" green="0.20969177782535553" blue="0.99831008911132812" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -746,10 +711,8 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZXn-Yf-pFc" userLabel="Bottom Left View">
-                                <rect key="frame" x="90" y="876" width="1565" height="100"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fTZ-r7-88x" customClass="AlignmentInsetView" customModule="Revert_tvOS" customModuleProvider="target">
-                                        <rect key="frame" x="758" y="25" width="50" height="50"/>
                                         <color key="backgroundColor" red="0.9859846830368042" green="0.0" blue="0.027009593322873116" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" id="aTr-X9-n41"/>
@@ -768,14 +731,12 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S7P-GI-TLs" userLabel="Left View">
-                                        <rect key="frame" x="0.0" y="40" width="758" height="20"/>
                                         <color key="backgroundColor" red="0.99987119436264038" green="0.99998223781585693" blue="0.99984109401702881" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="Dvb-J1-L0d"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CvC-ya-xq5" userLabel="Right View">
-                                        <rect key="frame" x="808" y="40" width="757" height="20"/>
                                         <color key="backgroundColor" red="0.99987119436264038" green="0.99998223781585693" blue="0.99984109401702881" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="FnJ-HR-onk"/>
@@ -801,7 +762,6 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uls-h5-Lq5" userLabel="Bottom Top Right">
-                                <rect key="frame" x="1663" y="876" width="167" height="60"/>
                                 <color key="backgroundColor" red="0.079384505748748779" green="0.60608792304992676" blue="0.1828572154045105" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="8N3-h3-uzG"/>
@@ -814,7 +774,6 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zXA-WG-emP" userLabel="Bottom Bottom Right">
-                                <rect key="frame" x="1663" y="944" width="167" height="32"/>
                                 <color key="backgroundColor" red="0.18545721471309662" green="0.79220128059387207" blue="0.67216956615447998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -823,37 +782,31 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Baseline Aligned" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qz0-mi-y6s">
-                                <rect key="frame" x="1058" y="619" width="370" height="61"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F8s-Kl-vgc">
-                                <rect key="frame" x="1436" y="634" width="104" height="43"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vertically Centered" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dfy-18-kzU">
-                                <rect key="frame" x="1058" y="688" width="421" height="61"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WYW-gA-DCz">
-                                <rect key="frame" x="1487" y="697" width="104" height="43"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Horizontally Centered" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eST-6h-VKt">
-                                <rect key="frame" x="1058" y="757" width="481" height="61"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uKV-M6-fjO">
-                                <rect key="frame" x="1247" y="826" width="104" height="43"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -911,9 +864,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Plp-tU-cGi">
-                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1036"/>
-                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Plp-tU-cGi"/>
                         </subviews>
                         <constraints>
                             <constraint firstItem="Plp-tU-cGi" firstAttribute="leading" secondItem="aCQ-F8-eg0" secondAttribute="leading" id="2GW-eZ-Xg0"/>
@@ -955,10 +906,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qCc-ht-ivH">
-                                            <rect key="frame" x="-1" y="28" width="300" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j0I-0T-ibi" customClass="CATextLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="300" id="AQ7-t0-sBX"/>
@@ -966,7 +915,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CATextLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LWr-yM-owq">
-                                                    <rect key="frame" x="68" y="208" width="165" height="35"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="lb7-go-yPn"/>
                                                     </constraints>
@@ -1005,10 +953,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d9g-zX-7wv">
-                                            <rect key="frame" x="-1" y="28" width="300" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TPD-8S-yME" customClass="CAEmitterLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="200" id="1p1-T6-knh"/>
@@ -1016,7 +962,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CAEmitterLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lSK-G4-lkD">
-                                                    <rect key="frame" x="47" y="208" width="206" height="35"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="KYa-Wv-PV1"/>
                                                     </constraints>
@@ -1055,10 +1000,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R1u-90-vgW">
-                                            <rect key="frame" x="-1" y="28" width="300" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kKm-jM-3tL" customClass="CAShapeLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="300" id="8rQ-Wx-bo3"/>
@@ -1066,7 +1009,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CAShapeLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1e2-39-EsZ">
-                                                    <rect key="frame" x="53" y="208" width="195" height="35"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="0Qh-tp-c8q"/>
                                                     </constraints>
@@ -1105,10 +1047,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eab-3q-B81">
-                                            <rect key="frame" x="-1" y="28" width="300" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5sr-T0-NYI" customClass="CAScrollLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="300" id="neg-TS-Fxr"/>
@@ -1116,7 +1056,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CAScrollLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3NR-Li-Boc">
-                                                    <rect key="frame" x="58" y="208" width="185" height="35"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="LKT-sr-avh"/>
                                                     </constraints>
@@ -1155,10 +1094,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dy1-Ri-IN2">
-                                            <rect key="frame" x="-1" y="28" width="300" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOl-vR-iRN" customClass="CATiledLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="200" id="GPH-pC-FFC"/>
@@ -1166,7 +1103,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CATiledLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ght-KC-iw6">
-                                                    <rect key="frame" x="64" y="208" width="173" height="35"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="Lqa-P2-324"/>
                                                     </constraints>
@@ -1205,10 +1141,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P1u-Xy-Ezd">
-                                            <rect key="frame" x="-1" y="28" width="300" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x4b-qn-XFZ" customClass="CAGradientLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="300" id="NYz-eg-3dS"/>
@@ -1216,7 +1150,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CAGradientLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MeM-sd-5Vm">
-                                                    <rect key="frame" x="85" y="208" width="130" height="35"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="DmV-w6-suG"/>
                                                     </constraints>
@@ -1255,10 +1188,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bww-Ka-Xbv">
-                                            <rect key="frame" x="27" y="28" width="244" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U9t-hX-9ja" customClass="CAReplicatorLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="-28" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="200" id="F3N-0f-vV3"/>
@@ -1266,7 +1197,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CAReplicatorLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xej-lp-Nvb">
-                                                    <rect key="frame" x="0.0" y="208" width="244" height="35"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <color key="textColor" red="0.16617307066917419" green="0.1662043035030365" blue="0.16616508364677429" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1304,10 +1234,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pax-2t-c5g">
-                                            <rect key="frame" x="-1" y="28" width="300" height="243"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vyJ-Cz-PkQ" customClass="CAEAGLLayerView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="300" id="MgH-yp-Y51"/>
@@ -1315,7 +1243,6 @@
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CAAEGLayer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jXE-cs-rAE">
-                                                    <rect key="frame" x="0.0" y="208" width="300" height="35"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <color key="textColor" red="0.16617307066917419" green="0.1662043035030365" blue="0.16616508364677429" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1369,10 +1296,8 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RjR-O2-gf9">
-                                <rect key="frame" x="1042" y="100" width="768" height="780"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hGp-9i-N1x">
-                                        <rect key="frame" x="0.0" y="0.0" width="768" height="780"/>
                                         <color key="backgroundColor" red="0.93655580282211304" green="0.552024245262146" blue="0.03212863951921463" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                 </subviews>
@@ -1381,10 +1306,8 @@
                                 </constraints>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ei1-0z-A3K">
-                                <rect key="frame" x="110" y="96" width="768" height="784"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Nw-9V-SO9">
-                                        <rect key="frame" x="0.0" y="0.0" width="768" height="784"/>
                                         <color key="backgroundColor" red="0.24911218881607056" green="0.66095209121704102" blue="0.92716234922409058" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                 </subviews>
@@ -1393,19 +1316,16 @@
                                 </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This StackView has infinite spacing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IT4-qF-qmA">
-                                <rect key="frame" x="102" y="60" width="785" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This StackView has NaN as spacing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZYW-2r-xVj">
-                                <rect key="frame" x="1026" y="-1" width="800" height="61"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trailing Space constant = CGFloat.min on this label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tVU-gF-R1R">
-                                <rect key="frame" x="110" y="940" width="1700" height="80"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="80" id="bm2-AY-Ytt"/>
                                 </constraints>
@@ -1457,35 +1377,28 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="xLv-uU-KMG">
-                                <rect key="frame" x="660" y="227" width="600" height="626"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="DMs-qS-iH4">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="86"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="System Button" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xlC-6U-NBK">
-                                                <rect key="frame" x="0.0" y="0.0" width="316" height="86"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pcV-P1-SPz">
-                                                <rect key="frame" x="405" y="0.0" width="195" height="86"/>
                                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                                 <state key="normal" title="Button"/>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="T8Z-0S-fXZ">
-                                        <rect key="frame" x="0.0" y="186" width="600" height="86"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom Button" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Odm-ax-Q0c">
-                                                <rect key="frame" x="0.0" y="0.0" width="316" height="86"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bj6-7a-AdB">
-                                                <rect key="frame" x="405" y="0.0" width="195" height="86"/>
                                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                                 <state key="normal" title="Button"/>
@@ -1496,31 +1409,25 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="LCT-Cd-TCW">
-                                        <rect key="frame" x="0.0" y="372" width="600" height="77"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail Disclosure Button" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hr9-W4-1yi">
-                                                <rect key="frame" x="0.0" y="0.0" width="316" height="77"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="detailDisclosure" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fft-eb-6w8">
-                                                <rect key="frame" x="483" y="0.0" width="117" height="77"/>
                                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="gnO-0a-maY">
-                                        <rect key="frame" x="0.0" y="549" width="600" height="77"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Contact Button" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xLd-IJ-kB8">
-                                                <rect key="frame" x="0.0" y="0.0" width="316" height="77"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="contactAdd" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IRf-YB-T5f">
-                                                <rect key="frame" x="483" y="0.0" width="117" height="77"/>
                                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                             </button>
                                         </subviews>
@@ -1574,10 +1481,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GWO-dW-5DH">
-                                            <rect key="frame" x="50" y="75" width="300" height="250"/>
                                             <subviews>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" editable="NO" text="Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing." textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kIF-cw-fST">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="200" id="ktc-9q-nUG"/>
@@ -1587,7 +1492,6 @@
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 </textView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="130" translatesAutoresizingMaskIntoConstraints="NO" id="KFu-q2-Ysj">
-                                                    <rect key="frame" x="87" y="215" width="127" height="35"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <color key="textColor" red="0.16617307066917419" green="0.1662043035030365" blue="0.16616508364677429" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1622,17 +1526,14 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jg8-Cp-3dU">
-                                            <rect key="frame" x="50" y="79" width="300" height="243"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="default_reveal" translatesAutoresizingMaskIntoConstraints="NO" id="ELS-fX-hZL">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="300" id="MSn-be-0vM"/>
                                                         <constraint firstAttribute="height" constant="200" id="ZbJ-np-X6K"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Image View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="130" translatesAutoresizingMaskIntoConstraints="NO" id="1u0-zS-ka0">
-                                                    <rect key="frame" x="74" y="208" width="152" height="35"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <color key="textColor" red="0.16617307066917419" green="0.1662043035030365" blue="0.16616508364677429" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1667,10 +1568,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4lA-me-DXZ">
-                                            <rect key="frame" x="50" y="170" width="300" height="60"/>
                                             <subviews>
                                                 <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="M2k-Mv-jjy">
-                                                    <rect key="frame" x="0.0" y="0.0" width="300" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="300" id="uZU-rR-M20"/>
                                                     </constraints>
@@ -1678,7 +1577,6 @@
                                                     <color key="trackTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </progressView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Progress View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="130" translatesAutoresizingMaskIntoConstraints="NO" id="p6c-xT-UEd">
-                                                    <rect key="frame" x="56" y="25" width="188" height="35"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <color key="textColor" red="0.16617307066917419" green="0.1662043035030365" blue="0.16616508364677429" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1713,7 +1611,6 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="130" translatesAutoresizingMaskIntoConstraints="NO" id="2Gf-dK-rmb">
-                                            <rect key="frame" x="164" y="183" width="72" height="35"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" red="0.16617307066917419" green="0.1662043035030365" blue="0.16616508364677429" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -1753,19 +1650,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cST-9k-P7P">
-                                <rect key="frame" x="90" y="60" width="1740" height="1080"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YLK-km-3E8" userLabel="Container Translate">
-                                        <rect key="frame" x="0.0" y="0.0" width="1740" height="180"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Translate (-20, 20)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GrE-fz-DgG">
-                                                <rect key="frame" x="698" y="20" width="344" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOM-vP-6mx" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="91" width="1640" height="80"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="80" id="vH1-XU-DVg"/>
@@ -1780,10 +1673,8 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nMF-zP-KRW" userLabel="Transformed View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="91" width="1640" height="80"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Translated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="prt-Ma-bjP">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1640" height="80"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                                         <color key="textColor" red="0.99675917625427246" green="0.86551940441131592" blue="0.9572068452835083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -1820,16 +1711,13 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2s4-yi-r57" userLabel="Container Scale">
-                                        <rect key="frame" x="0.0" y="360" width="1740" height="180"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scale (50%)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oAH-wD-gtH">
-                                                <rect key="frame" x="760" y="20" width="221" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iuj-rw-ZVs" userLabel="Original Scale View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="101" width="1640" height="80"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="80" id="RrW-rH-oxE"/>
@@ -1844,10 +1732,8 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ck4-Sp-cNQ" userLabel="Scaled View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="101" width="1640" height="80"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scaled Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.10000000000000001" translatesAutoresizingMaskIntoConstraints="NO" id="7Yr-Cp-wdl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1640" height="80"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                                         <color key="textColor" red="0.99675917625427246" green="0.86551940441131592" blue="0.9572068452835083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -1884,16 +1770,13 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4vw-H5-Jt0" userLabel="Container Rotate">
-                                        <rect key="frame" x="0.0" y="180" width="1740" height="180"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotate (15°)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qRY-fh-LSR">
-                                                <rect key="frame" x="762" y="20" width="217" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ptE-TK-GaT" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="91" width="1640" height="80"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="80" id="e0U-Nj-W3g"/>
@@ -1908,10 +1791,8 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t1Y-oo-oIk" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="91" width="1640" height="80"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="scK-ju-dcJ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1640" height="80"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                                         <color key="textColor" red="0.99675917625427246" green="0.86551940441131592" blue="0.9572068452835083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -1997,19 +1878,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8j6-aN-FN0">
-                                <rect key="frame" x="90" y="60" width="1740" height="960"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ka-6g-bej" userLabel="Y Rotate">
-                                        <rect key="frame" x="0.0" y="0.0" width="1740" height="150"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Y Rotate (15°)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s9f-XD-MnC">
-                                                <rect key="frame" x="744" y="0.0" width="253" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W99-4Q-Ptm" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="80" id="hyf-g9-JKU"/>
@@ -2024,10 +1901,8 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3I4-iT-AYg" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VXT-xi-rJl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1640" height="80"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                                         <color key="textColor" red="0.99680936336517334" green="0.86750483512878418" blue="0.95383268594741821" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -2064,16 +1939,13 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uxQ-UX-dI1" userLabel="X Rotate">
-                                        <rect key="frame" x="0.0" y="150" width="1740" height="150"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="X Rotate (15°)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gvJ-jh-FLz">
-                                                <rect key="frame" x="743" y="0.0" width="254" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bqp-d2-Lob" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="80" id="wyY-8h-h9k"/>
@@ -2088,10 +1960,8 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QNk-Sj-PpA" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TRt-zl-Ybn">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1640" height="80"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                                         <color key="textColor" red="0.99680936336517334" green="0.86750483512878418" blue="0.95383268594741821" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -2127,16 +1997,13 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pyn-uB-MfJ" userLabel="XY Rotate">
-                                        <rect key="frame" x="0.0" y="450" width="1740" height="150"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="XY Rotate (15°)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v65-aT-MYb">
-                                                <rect key="frame" x="730" y="0.0" width="280" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C9n-gr-EkR" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="80" id="jMj-me-Axt"/>
@@ -2151,10 +2018,8 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nBL-0A-Pri" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mo8-cB-Obc">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1640" height="80"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                                         <color key="textColor" red="0.99675917625427246" green="0.86551940441131592" blue="0.9572068452835083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -2190,16 +2055,13 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qpw-oB-5aU" userLabel="Z Rotate">
-                                        <rect key="frame" x="0.0" y="300" width="1740" height="150"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Z Rotate (15°)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AsX-mN-ezH">
-                                                <rect key="frame" x="743" y="0.0" width="254" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lPy-pR-OcN" userLabel="Original Rotate View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="80" id="CvA-rL-ivw"/>
@@ -2214,10 +2076,8 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HFw-3s-Dae" userLabel="Rotated View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="50" y="71" width="1640" height="80"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rotated Subview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ryr-Hg-ZQb">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1640" height="80"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="45"/>
                                                         <color key="textColor" red="0.99675917625427246" green="0.86551940441131592" blue="0.9572068452835083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -2309,19 +2169,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E7S-8z-ts3">
-                                <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I6x-yA-AwD" userLabel="Anchor Point">
-                                        <rect key="frame" x="0.0" y="40" width="1920" height="400"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Anchor Point (0.25, 0.25)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TcN-Od-JJE">
-                                                <rect key="frame" x="727" y="20" width="466" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qjB-yV-R09" userLabel="Original Transform View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="810" y="91" width="300" height="300"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.25" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="4Gv-Di-9JW"/>
@@ -2337,7 +2193,6 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jcn-NB-yCf" userLabel="Transform View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="810" y="91" width="300" height="300"/>
                                                 <color key="backgroundColor" red="0.76608371734619141" green="0.12616141140460968" blue="0.99884259700775146" alpha="0.85098039219999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="9sJ-Do-4PP"/>
@@ -2364,19 +2219,15 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Kr-Nn-w4C" userLabel="Bounds Change">
-                                        <rect key="frame" x="0.0" y="380" width="1920" height="400"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bounds Change (?, ?)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qkP-s4-nhQ">
-                                                <rect key="frame" x="761" y="20" width="398" height="51"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rc9-Nd-PMc" userLabel="Bounds Change View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                <rect key="frame" x="810" y="91" width="300" height="300"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z6N-Fy-VL2" userLabel="Transform View" customClass="HairlineBorderView" customModule="Revert_tvOS" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
                                                         <color key="backgroundColor" red="0.76608371734619141" green="0.12616141140460968" blue="0.99884259700775146" alpha="0.85098039219999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -2461,9 +2312,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gFt-rV-fjz" customClass="DeepView" customModule="Revert_tvOS" customModuleProvider="target">
-                                <rect key="frame" x="90" y="60" width="1740" height="960"/>
-                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gFt-rV-fjz" customClass="DeepView" customModule="Revert_tvOS" customModuleProvider="target"/>
                         </subviews>
                         <constraints>
                             <constraint firstItem="gFt-rV-fjz" firstAttribute="top" secondItem="lIb-EX-hHx" secondAttribute="bottom" constant="60" id="2kg-if-3gw"/>
@@ -2498,9 +2347,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="170" height="170"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ncx-lw-kCg" customClass="DeepView" customModule="Revert_tvOS" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="170" height="170"/>
-                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ncx-lw-kCg" customClass="DeepView" customModule="Revert_tvOS" customModuleProvider="target"/>
                                     </subviews>
                                 </view>
                                 <constraints>
@@ -2588,13 +2435,10 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q3k-fA-4GD" userLabel="Container">
-                                <rect key="frame" x="0.0" y="60" width="1920" height="810"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="800" verticalCompressionResistancePriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="ml3-CY-mgV" userLabel="Center View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_tvOS" customModuleProvider="target">
-                                        <rect key="frame" x="920" y="365" width="80" height="80"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ebx-85-dhz">
-                                                <rect key="frame" x="8" y="8" width="64" height="64"/>
                                                 <color key="backgroundColor" red="0.79589802026748657" green="1" blue="0.23661470413208008" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -2620,7 +2464,6 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ou0-qC-1Pb" userLabel="Right View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_tvOS" customModuleProvider="target">
-                                        <rect key="frame" x="1024" y="357" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.98700940608978271" green="0.62185144424438477" blue="0.03442937508225441" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Right View"/>
                                         <constraints>
@@ -2633,7 +2476,6 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qSc-hW-wrq" userLabel="Bottom View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_tvOS" customModuleProvider="target">
-                                        <rect key="frame" x="928" y="469" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.17552228271961212" green="0.80860555171966553" blue="0.71378350257873535" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Bottom View"/>
                                         <constraints>
@@ -2646,7 +2488,6 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n6U-F2-dD7" userLabel="Left View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_tvOS" customModuleProvider="target">
-                                        <rect key="frame" x="816" y="373" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.75690394639968872" green="0.17739748954772949" blue="0.99884581565856934" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Left View"/>
                                         <constraints>
@@ -2659,7 +2500,6 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7V2-f5-C5V" userLabel="Top View" customClass="CustomIntrinsicContentSizeView" customModule="Revert_tvOS" customModuleProvider="target">
-                                        <rect key="frame" x="912" y="261" width="80" height="80"/>
                                         <color key="backgroundColor" red="0.35848003625869751" green="0.70734065771102905" blue="0.99879956245422363" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" label="Top View"/>
                                         <constraints>
@@ -2678,16 +2518,13 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6c8-7v-Iyh" customClass="ButtonsMarginsAdjustingView" customModule="Revert_tvOS" customModuleProvider="target">
-                                <rect key="frame" x="20" y="870" width="1880" height="150"/>
                                 <subviews>
                                     <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="cSf-Aj-34F">
-                                        <rect key="frame" x="740" y="70" width="400" height="10"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="400" id="Xdq-Ms-JUk"/>
                                         </constraints>
                                     </progressView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iEI-dK-INO">
-                                        <rect key="frame" x="1240" y="25" width="200" height="100"/>
                                         <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                         <state key="normal" title="+"/>
                                         <connections>
@@ -2695,7 +2532,6 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ckc-5Q-oih">
-                                        <rect key="frame" x="440" y="25" width="200" height="100"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="200" id="Bpk-ff-wVD"/>
                                             <constraint firstAttribute="height" constant="100" id="b0w-yl-1bi"/>
@@ -2781,14 +2617,14 @@
                                     <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YOn-4U-MZU">
-                                            <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
-                                        </imageView>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YOn-4U-MZU"/>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K07-S8-ivF">
-                                            <rect key="frame" x="129" y="240" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
+                                            <variation key="userInterfaceStyle=dark">
+                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            </variation>
                                         </label>
                                     </subviews>
                                 </view>
@@ -2866,11 +2702,8 @@
                                     <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dDX-qj-VTX">
-                                            <rect key="frame" x="0.0" y="0.0" width="300" height="200"/>
-                                        </imageView>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dDX-qj-VTX"/>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P7e-aV-rMX">
-                                            <rect key="frame" x="129" y="240" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -2943,19 +2776,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="1Pj-O0-8C6">
-                                <rect key="frame" x="460" y="421" width="1000" height="238"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="NOr-Hp-g0J">
-                                        <rect key="frame" x="0.0" y="0.0" width="1000" height="69"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Segmented Control (Title)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PjG-PB-DEU">
-                                                <rect key="frame" x="0.0" y="0.0" width="363" height="69"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="byT-9l-iCp">
-                                                <rect key="frame" x="646" y="0.0" width="354" height="70"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <segments>
                                                     <segment title="First"/>
@@ -2965,16 +2794,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="M9h-Cp-wdS">
-                                        <rect key="frame" x="0.0" y="169" width="1000" height="69"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Segmented Control (Image)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OyM-3Z-kfq">
-                                                <rect key="frame" x="0.0" y="0.0" width="363" height="69"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="kbR-UI-x3Z">
-                                                <rect key="frame" x="646" y="0.0" width="354" height="70"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <segments>
                                                     <segment title="" image="delorian"/>
@@ -3019,19 +2845,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="100" translatesAutoresizingMaskIntoConstraints="NO" id="1S7-gS-uAI">
-                                <rect key="frame" x="460" y="444" width="1000" height="192"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="80" translatesAutoresizingMaskIntoConstraints="NO" id="nX6-FD-LIQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="1000" height="46"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rounded Rect TextField" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jtL-2P-0n1">
-                                                <rect key="frame" x="0.0" y="0.0" width="311" height="46"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LmU-Hf-udV">
-                                                <rect key="frame" x="391" y="0.0" width="609" height="46"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -3039,16 +2861,13 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="80" translatesAutoresizingMaskIntoConstraints="NO" id="h8b-43-Pc7">
-                                        <rect key="frame" x="0.0" y="146" width="1000" height="46"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Border TextField" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jcv-sx-8PK">
-                                                <rect key="frame" x="0.0" y="0.0" width="311" height="46"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WcC-lb-lZW">
-                                                <rect key="frame" x="391" y="0.0" width="609" height="46"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -3086,11 +2905,6 @@
         <image name="reveal_pretty" width="800" height="600"/>
         <image name="x-wing" width="45" height="16"/>
     </resources>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <nil key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation" orientation="landscapeRight"/>
-        <simulatedScreenMetrics key="destination"/>
-    </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
         <segue reference="uRr-Hb-cuq"/>
         <segue reference="kmn-Ux-9Fc"/>

--- a/Revert-tvOS/Base.lproj/Main.storyboard
+++ b/Revert-tvOS/Base.lproj/Main.storyboard
@@ -797,6 +797,9 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
+                                <variation key="userInterfaceStyle=dark">
+                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F8s-Kl-vgc">
                                 <fontDescription key="fontDescription" type="system" pointSize="36"/>
@@ -807,6 +810,9 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
+                                <variation key="userInterfaceStyle=dark">
+                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WYW-gA-DCz">
                                 <fontDescription key="fontDescription" type="system" pointSize="36"/>
@@ -817,6 +823,9 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="51"/>
                                 <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
+                                <variation key="userInterfaceStyle=dark">
+                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uKV-M6-fjO">
                                 <fontDescription key="fontDescription" type="system" pointSize="36"/>

--- a/Revert-tvOS/Resources/Info.plist
+++ b/Revert-tvOS/Resources/Info.plist
@@ -28,5 +28,7 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Automatic</string>
 </dict>
 </plist>

--- a/Shared/Sources/AutoResizingMaskViewSource.swift
+++ b/Shared/Sources/AutoResizingMaskViewSource.swift
@@ -47,7 +47,7 @@ final class AutoResizingMaskViewSource {
     #endif
   }()
 
-  private(set) lazy var flexibleWidthHeightView: UserInterfaceStyleAwareView = {
+  private(set) lazy var flexibleWidthHeightView: UIView = {
     // Back: Flexible Height / Width View
     let frame = CGRect(origin: self.outerOrigin, size: self.flexibleWidthHeightSize)
     let flexibleWidthHeightView = self.bakeViewWithFrame(frame)
@@ -57,7 +57,7 @@ final class AutoResizingMaskViewSource {
     return flexibleWidthHeightView
   }()
 
-  private(set) lazy var flexibleWidthView: UserInterfaceStyleAwareView = {
+  private(set) lazy var flexibleWidthView: UIView = {
     let flexibleWidthSize = CGSize(
       width: self.flexibleWidthHeightSize.width - (2 * type(of: self).innerPadding),
       height: type(of: self).defaultViewSideLength
@@ -70,7 +70,7 @@ final class AutoResizingMaskViewSource {
     return flexibleWidthView
   }()
 
-  private(set) lazy var flexibleHeightLeftRightView: UserInterfaceStyleAwareView = {
+  private(set) lazy var flexibleHeightLeftRightView: UIView = {
     let flexibleHeightLeftRightSize = CGSize(
       width: type(of: self).defaultViewSideLength,
       height: self.flexibleWidthHeightSize.height - self.flexibleWidthView.frame.maxY - (2 * type(of: self).innerPadding)
@@ -89,7 +89,7 @@ final class AutoResizingMaskViewSource {
     return flexibleHeightLeftRightView
   }()
 
-  private(set) lazy var leftFlexibleTopBottomView: UserInterfaceStyleAwareView = {
+  private(set) lazy var leftFlexibleTopBottomView: UIView = {
     let leftFlexibleTopBottomOrigin = CGPoint(
       x: type(of: self).innerPadding,
       y: self.flexibleHeightLeftRightView.frame.midY - self.flexibleTopBottomSize.height / 2
@@ -102,7 +102,7 @@ final class AutoResizingMaskViewSource {
     return leftFlexibleTopBottomView
   }()
 
-  private(set) lazy var rightFlexibleTopBottomView: UserInterfaceStyleAwareView = {
+  private(set) lazy var rightFlexibleTopBottomView: UIView = {
     let rightFlexibleTopBottomOrigin = CGPoint(
       x: self.flexibleWidthHeightView.bounds.width - type(of: self).innerPadding - type(of: self).leftRightWidth,
       y: self.flexibleHeightLeftRightView.frame.midY - self.flexibleTopBottomSize.height / 2
@@ -120,15 +120,26 @@ final class AutoResizingMaskViewSource {
     let view = UserInterfaceStyleAwareView(frame: frame)
     view.layer.cornerRadius = type(of: self).cornerRadius
     view.layer.borderWidth = type(of: self).borderWidth
-    view.layer.borderColor = view.borderColor
     return view
   }
 }
 
-class UserInterfaceStyleAwareView: UIView {
+private class UserInterfaceStyleAwareView: UIView {
 
-  var borderColor: CGColor {
-    
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.layer.borderColor = self.borderColor
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private var borderColor: CGColor {
+
     #if os(tvOS)
 
       guard #available(tvOS 10.0, *) else {
@@ -160,6 +171,6 @@ class UserInterfaceStyleAwareView: UIView {
         self.layer.borderColor = self.borderColor
       }
     }
-  
+
   #endif
 }

--- a/Shared/Sources/AutoResizingMaskViewSource.swift
+++ b/Shared/Sources/AutoResizingMaskViewSource.swift
@@ -128,7 +128,9 @@ final class AutoResizingMaskViewSource {
 class UserInterfaceStyleAwareView: UIView {
 
   var borderColor: CGColor {
+    
     #if os(tvOS)
+
       guard #available(tvOS 10.0, *) else {
         return UIColor.black.cgColor
       }
@@ -139,9 +141,13 @@ class UserInterfaceStyleAwareView: UIView {
       case .light, .unspecified:
         return UIColor.black.cgColor
       }
+
     #else
+
       return UIColor.white.cgColor
+
     #endif
+
   }
 
   #if os(tvOS)

--- a/Shared/Sources/AutoResizingMaskViewSource.swift
+++ b/Shared/Sources/AutoResizingMaskViewSource.swift
@@ -144,10 +144,16 @@ class UserInterfaceStyleAwareView: UIView {
     #endif
   }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    guard #available(tvOS 10.0, *) else { return }
-    if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
-      self.layer.borderColor = self.borderColor
+  #if os(tvOS)
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      super.traitCollectionDidChange(previousTraitCollection)
+
+      guard #available(tvOS 10.0, *) else { return }
+      if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+        self.layer.borderColor = self.borderColor
+      }
     }
-  }
+  
+  #endif
 }

--- a/Shared/Sources/CollectionViewCells.swift
+++ b/Shared/Sources/CollectionViewCells.swift
@@ -91,10 +91,9 @@ class TextFieldControlCell: CollectionViewCell {
   final class HomeCollectionCell: CollectionViewCell {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-      if #available(tvOS 10.0, *) {
-        if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
-          self.configureTitleLabelTextColor()
-        }
+      guard #available(tvOS 10.0, *) else { return }
+      if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+        self.configureTitleLabelTextColor()
       }
     }
 
@@ -114,13 +113,15 @@ class TextFieldControlCell: CollectionViewCell {
       if self.isFocused {
         self.titleLabel.textColor = UIColor.white
       } else {
-        if #available(tvOS 10.0, *) {
-          if traitCollection.userInterfaceStyle == .dark {
-            self.titleLabel.textColor = UIColor.lightGray
-          } else {
-            self.titleLabel.textColor = UIColor.black
-          }
-        } else {
+        guard #available(tvOS 10.0, *) else {
+          self.titleLabel.textColor = UIColor.black
+          return
+        }
+
+        switch self.traitCollection.userInterfaceStyle {
+        case .dark:
+          self.titleLabel.textColor = UIColor.lightGray
+        case .light, .unspecified:
           self.titleLabel.textColor = UIColor.black
         }
       }

--- a/Shared/Sources/CollectionViewCells.swift
+++ b/Shared/Sources/CollectionViewCells.swift
@@ -22,13 +22,6 @@ class CollectionViewCell: UICollectionViewCell {
     self.applyDynamicType()
   }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    guard #available(tvOS 10.0, *) else { return }
-    if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
-      self.configureTitleLabelTextColor()
-    }
-  }
-
   func applyDynamicType(_ notification: Notification? = nil) {
     self.titleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
     self.subheadLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.subheadline)
@@ -39,23 +32,37 @@ class CollectionViewCell: UICollectionViewCell {
   @IBOutlet fileprivate(set) weak var titleLabel: UILabel!
   @IBOutlet private(set) weak var subheadLabel: UILabel!
 
-  fileprivate func configureTitleLabelTextColor() {
-    if self.isFocused {
-      self.titleLabel.textColor = UIColor.white
-    } else {
-      guard #available(tvOS 10.0, *) else {
-        self.titleLabel.textColor = UIColor.black
-        return
-      }
+  #if os(tvOS)
 
-      switch self.traitCollection.userInterfaceStyle {
-      case .dark:
-        self.titleLabel.textColor = UIColor.lightGray
-      case .light, .unspecified:
-        self.titleLabel.textColor = UIColor.black
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      super.traitCollectionDidChange(previousTraitCollection)
+
+      guard #available(tvOS 10.0, *) else { return }
+      if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+        self.configureTitleLabelTextColor()
       }
     }
-  }
+
+    fileprivate func configureTitleLabelTextColor() {
+      if self.isFocused {
+        self.titleLabel.textColor = UIColor.white
+      } else {
+        guard #available(tvOS 10.0, *) else {
+          self.titleLabel.textColor = UIColor.black
+          return
+        }
+
+        switch self.traitCollection.userInterfaceStyle {
+        case .dark:
+          self.titleLabel.textColor = UIColor.lightGray
+        case .light, .unspecified:
+          self.titleLabel.textColor = UIColor.black
+        }
+      }
+    }
+
+  #endif
+
 }
 
 class TextFieldControlCell: CollectionViewCell {

--- a/Shared/Sources/CollectionViewCells.swift
+++ b/Shared/Sources/CollectionViewCells.swift
@@ -22,6 +22,13 @@ class CollectionViewCell: UICollectionViewCell {
     self.applyDynamicType()
   }
 
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    guard #available(tvOS 10.0, *) else { return }
+    if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+      self.configureTitleLabelTextColor()
+    }
+  }
+
   func applyDynamicType(_ notification: Notification? = nil) {
     self.titleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
     self.subheadLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.subheadline)
@@ -31,6 +38,24 @@ class CollectionViewCell: UICollectionViewCell {
 
   @IBOutlet fileprivate(set) weak var titleLabel: UILabel!
   @IBOutlet private(set) weak var subheadLabel: UILabel!
+
+  fileprivate func configureTitleLabelTextColor() {
+    if self.isFocused {
+      self.titleLabel.textColor = UIColor.white
+    } else {
+      guard #available(tvOS 10.0, *) else {
+        self.titleLabel.textColor = UIColor.black
+        return
+      }
+
+      switch self.traitCollection.userInterfaceStyle {
+      case .dark:
+        self.titleLabel.textColor = UIColor.lightGray
+      case .light, .unspecified:
+        self.titleLabel.textColor = UIColor.black
+      }
+    }
+  }
 }
 
 class TextFieldControlCell: CollectionViewCell {
@@ -90,13 +115,6 @@ class TextFieldControlCell: CollectionViewCell {
 
   final class HomeCollectionCell: CollectionViewCell {
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-      guard #available(tvOS 10.0, *) else { return }
-      if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
-        self.configureTitleLabelTextColor()
-      }
-    }
-
     override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
       super.didUpdateFocus(in: context, with: coordinator)
 
@@ -109,22 +127,5 @@ class TextFieldControlCell: CollectionViewCell {
 
     @IBOutlet private(set) weak var imageView: UIImageView!
 
-    private func configureTitleLabelTextColor() {
-      if self.isFocused {
-        self.titleLabel.textColor = UIColor.white
-      } else {
-        guard #available(tvOS 10.0, *) else {
-          self.titleLabel.textColor = UIColor.black
-          return
-        }
-
-        switch self.traitCollection.userInterfaceStyle {
-        case .dark:
-          self.titleLabel.textColor = UIColor.lightGray
-        case .light, .unspecified:
-          self.titleLabel.textColor = UIColor.black
-        }
-      }
-    }
   }
 #endif

--- a/Shared/Sources/CollectionViewCells.swift
+++ b/Shared/Sources/CollectionViewCells.swift
@@ -127,7 +127,7 @@ class TextFieldControlCell: CollectionViewCell {
 
       coordinator.addCoordinatedAnimations({
         self.configureTitleLabelTextColor()
-        }, completion: nil)
+      }, completion: nil)
     }
 
     // MARK: Private

--- a/Shared/Sources/CollectionViewCells.swift
+++ b/Shared/Sources/CollectionViewCells.swift
@@ -90,20 +90,40 @@ class TextFieldControlCell: CollectionViewCell {
 
   final class HomeCollectionCell: CollectionViewCell {
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      if #available(tvOS 10.0, *) {
+        if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+          self.configureTitleLabelTextColor()
+        }
+      }
+    }
+
     override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
       super.didUpdateFocus(in: context, with: coordinator)
 
       coordinator.addCoordinatedAnimations({
-        if self.isFocused {
-          self.titleLabel.textColor = UIColor.white
-        } else {
-          self.titleLabel.textColor = UIColor.black
-        }
-      }, completion: nil)
+        self.configureTitleLabelTextColor()
+        }, completion: nil)
     }
 
     // MARK: Private
 
     @IBOutlet private(set) weak var imageView: UIImageView!
+
+    private func configureTitleLabelTextColor() {
+      if self.isFocused {
+        self.titleLabel.textColor = UIColor.white
+      } else {
+        if #available(tvOS 10.0, *) {
+          if traitCollection.userInterfaceStyle == .dark {
+            self.titleLabel.textColor = UIColor.lightGray
+          } else {
+            self.titleLabel.textColor = UIColor.black
+          }
+        } else {
+          self.titleLabel.textColor = UIColor.black
+        }
+      }
+    }
   }
 #endif

--- a/Shared/Sources/TableViewCells.swift
+++ b/Shared/Sources/TableViewCells.swift
@@ -39,21 +39,6 @@ class BasicCell: UITableViewCell {
     self.applyDynamicType()
   }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    guard #available(tvOS 10.0, *) else { return }
-    if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
-      self.configureTitleLabelTextColor()
-    }
-  }
-
-  override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-    super.didUpdateFocus(in: context, with: coordinator)
-
-    coordinator.addCoordinatedAnimations({
-      self.configureTitleLabelTextColor()
-      }, completion: nil)
-  }
-
   func applyDynamicType(_ notification: Notification? = nil) {
     self.titleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
     self.subtitleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.footnote)
@@ -64,20 +49,41 @@ class BasicCell: UITableViewCell {
   @IBOutlet private(set) weak var titleLabel: UILabel!
   @IBOutlet private(set) weak var subtitleLabel: UILabel!
 
-  private func configureTitleLabelTextColor() {
-    guard #available(tvOS 10.0, *) else {
-      return
+  #if os(tvOS)
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+      super.traitCollectionDidChange(previousTraitCollection)
+
+      guard #available(tvOS 10.0, *) else { return }
+      if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+        self.configureTitleLabelTextColor()
+      }
     }
 
-    switch self.traitCollection.userInterfaceStyle {
-    case .dark:
-      if self.isFocused {
-        self.titleLabel.textColor = UIColor.darkGray
-      } else {
-        self.titleLabel.textColor = UIColor.white
-      }
-    case .light, .unspecified:
-      self.titleLabel.textColor = UIColor.black
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+      super.didUpdateFocus(in: context, with: coordinator)
+
+      coordinator.addCoordinatedAnimations({
+        self.configureTitleLabelTextColor()
+      }, completion: nil)
     }
-  }
+
+    private func configureTitleLabelTextColor() {
+      guard #available(tvOS 10.0, *) else {
+        return
+      }
+
+      switch self.traitCollection.userInterfaceStyle {
+      case .dark:
+        if self.isFocused {
+          self.titleLabel.textColor = UIColor.darkGray
+        } else {
+          self.titleLabel.textColor = UIColor.white
+        }
+      case .light, .unspecified:
+        self.titleLabel.textColor = UIColor.black
+      }
+    }
+
+  #endif
 }

--- a/Shared/Sources/TableViewCells.swift
+++ b/Shared/Sources/TableViewCells.swift
@@ -39,6 +39,21 @@ class BasicCell: UITableViewCell {
     self.applyDynamicType()
   }
 
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    guard #available(tvOS 10.0, *) else { return }
+    if self.traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+      self.configureTitleLabelTextColor()
+    }
+  }
+
+  override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    super.didUpdateFocus(in: context, with: coordinator)
+
+    coordinator.addCoordinatedAnimations({
+      self.configureTitleLabelTextColor()
+      }, completion: nil)
+  }
+
   func applyDynamicType(_ notification: Notification? = nil) {
     self.titleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
     self.subtitleLabel?.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.footnote)
@@ -48,4 +63,21 @@ class BasicCell: UITableViewCell {
 
   @IBOutlet private(set) weak var titleLabel: UILabel!
   @IBOutlet private(set) weak var subtitleLabel: UILabel!
+
+  private func configureTitleLabelTextColor() {
+    guard #available(tvOS 10.0, *) else {
+      return
+    }
+
+    switch self.traitCollection.userInterfaceStyle {
+    case .dark:
+      if self.isFocused {
+        self.titleLabel.textColor = UIColor.darkGray
+      } else {
+        self.titleLabel.textColor = UIColor.white
+      }
+    case .light, .unspecified:
+      self.titleLabel.textColor = UIColor.black
+    }
+  }
 }

--- a/Shared/Sources/TableViewCells.swift
+++ b/Shared/Sources/TableViewCells.swift
@@ -76,12 +76,12 @@ class BasicCell: UITableViewCell {
       switch self.traitCollection.userInterfaceStyle {
       case .dark:
         if self.isFocused {
-          self.titleLabel.textColor = UIColor.darkGray
+          self.titleLabel.textColor = .darkGray
         } else {
-          self.titleLabel.textColor = UIColor.white
+          self.titleLabel.textColor = .white
         }
       case .light, .unspecified:
-        self.titleLabel.textColor = UIColor.black
+        self.titleLabel.textColor = .black
       }
     }
 

--- a/Shared/Sources/UIColor+Revert.swift
+++ b/Shared/Sources/UIColor+Revert.swift
@@ -36,5 +36,5 @@ extension UIColor {
   static func graySelectionColor() -> UIColor {
     return UIColor(white: 215 / 255, alpha: 1)
   }
-  
+
 }

--- a/Shared/Sources/UIColor+Revert.swift
+++ b/Shared/Sources/UIColor+Revert.swift
@@ -36,12 +36,5 @@ extension UIColor {
   static func graySelectionColor() -> UIColor {
     return UIColor(white: 215 / 255, alpha: 1)
   }
-
-  static func borderColor() -> UIColor {
-    #if os(tvOS)
-      return UIColor.black
-    #else
-      return UIColor.white
-    #endif
-  }
+  
 }


### PR DESCRIPTION
This PR adds support for the dark style user interface introduced in tvOS 10.

Colors for when the app is presented with the dark style have been based on equivalent views that are presented on black backgrounds in iOS already.