### PR TITLE
Replace fileprivate -> private

### DIFF
--- a/Revert-tvOS/Sources/SearchViewController.swift
+++ b/Revert-tvOS/Sources/SearchViewController.swift
@@ -39,7 +39,7 @@ final class SearchViewController: UICollectionViewController {
   private let dataSource: CollectionDataSource<HomeSection, HomeCollectionCell>
   private let sections: [HomeSection] = RevertItems.home.data()
 
-  fileprivate var searchText: String? {
+  private var searchText: String? {
     didSet {
       guard self.searchText != oldValue else {
         // We don't want to keep reloading content if the search text has not changed.

--- a/Revert/Sources/WebViewController.swift
+++ b/Revert/Sources/WebViewController.swift
@@ -74,7 +74,7 @@ final class WebViewController: RevertViewController {
     self.topConstraint = topConstraint
   }
 
-  fileprivate func showFailAlert() {
+  private func showFailAlert() {
     let alertViewController = UIAlertController(
       title: NSLocalizedString("Error", comment: "Alert title on content failed loading"),
       message: NSLocalizedString("Failed to load content. Make sure you're connected to the internet and try again.", comment: "Alert message on content failed loading"),

--- a/Shared/Sources/AlertViewController.swift
+++ b/Shared/Sources/AlertViewController.swift
@@ -28,7 +28,7 @@ final class AlertViewController: RevertTableViewController {
 // MARK: - UIAlertController Presenter
 extension AlertViewController {
 
-  fileprivate func displayAlertControllerForWithStyle(_ style: UIAlertController.Style, fromView: UIView) {
+  private func displayAlertControllerForWithStyle(_ style: UIAlertController.Style, fromView: UIView) {
     let alertViewController = UIAlertController.exampleAlertControllerWithStyle(style)
     alertViewController.popoverPresentationController?.sourceView = fromView
     self.present(alertViewController, animated: true, completion: nil)
@@ -49,7 +49,7 @@ private enum Identifier: String {
 
   extension AlertViewController {
 
-    fileprivate func displayCorrespondingAlertForIdentifier(_ identifier: Identifier, fromView: UIView) {
+    private func displayCorrespondingAlertForIdentifier(_ identifier: Identifier, fromView: UIView) {
       switch identifier {
       case .alertView:
         AlertViewController.showExampleAlertView()
@@ -67,7 +67,7 @@ private enum Identifier: String {
 
   extension AlertViewController {
 
-    fileprivate func displayCorrespondingAlertForIdentifier(_ identifier: Identifier, fromView: UIView) {
+    private func displayCorrespondingAlertForIdentifier(_ identifier: Identifier, fromView: UIView) {
       let alertStyle: UIAlertController.Style = identifier == .alertController ? .alert : .actionSheet
       self.displayAlertControllerForWithStyle(alertStyle, fromView: fromView)
     }

--- a/Shared/Sources/AutoLayoutMarginsViewController.swift
+++ b/Shared/Sources/AutoLayoutMarginsViewController.swift
@@ -33,7 +33,7 @@ final class AutoLayoutMarginsViewController: RevertViewController, MarginsAdjust
 
   private var lastUpdateSquaresWidthSize: CGSize?
 
-  @IBOutlet fileprivate var marginsAdjustingView: MarginsAdjustingView!
+  @IBOutlet private var marginsAdjustingView: MarginsAdjustingView!
   @IBOutlet private var centerViewWidthConstraint: NSLayoutConstraint!
   @IBOutlet private var containerViewBottomConstraint: NSLayoutConstraint!
   @IBOutlet private var centerView: UIView!

--- a/Shared/Sources/CollectionViewCells.swift
+++ b/Shared/Sources/CollectionViewCells.swift
@@ -29,7 +29,7 @@ class CollectionViewCell: UICollectionViewCell {
 
   // MARK: Private
 
-  @IBOutlet fileprivate(set) weak var titleLabel: UILabel!
+  @IBOutlet private(set) weak var titleLabel: UILabel!
   @IBOutlet private(set) weak var subheadLabel: UILabel!
 
   #if os(tvOS)

--- a/Shared/Sources/ControlsViewController.swift
+++ b/Shared/Sources/ControlsViewController.swift
@@ -32,7 +32,7 @@ final class ControlsViewController: RevertCollectionViewController {
   // MARK: Private
 
   #if os(iOS)
-    fileprivate let keyboardHandler = KeyboardHandler()
+    private let keyboardHandler = KeyboardHandler()
   #endif
 
   private var dataSource: ControlsDataSource?
@@ -42,7 +42,7 @@ final class ControlsViewController: RevertCollectionViewController {
 
   extension ControlsViewController {
 
-    fileprivate func setupKeyboardHandler() {
+    private func setupKeyboardHandler() {
       // iOS 9 UICollectionViewControllers kinda handle the keyboard by themselves
       // The behaviour is not perfect, but there is no way to opt-out
       if NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_8_4 {

--- a/Shared/Sources/CountriesViewController.swift
+++ b/Shared/Sources/CountriesViewController.swift
@@ -4,8 +4,8 @@
 import UIKit
 
 final class CountriesViewController: RevertTableViewController {
-  fileprivate let dataSource: DataSource<CountrySection, BasicCell>
-  fileprivate var refreshTimer: Timer?
+  private let dataSource: DataSource<CountrySection, BasicCell>
+  private var refreshTimer: Timer?
 
   required init?(coder aDecoder: NSCoder) {
     self.dataSource = DataSource(
@@ -28,7 +28,7 @@ final class CountriesViewController: RevertTableViewController {
     #endif
   }
 
-  fileprivate static func footerLabelWithText(_ text: String?) -> UILabel {
+  private static func footerLabelWithText(_ text: String?) -> UILabel {
     let label = UILabel()
     label.backgroundColor = UIColor.white
     label.text = text
@@ -85,7 +85,7 @@ private extension CountriesViewController {
 
   extension CountriesViewController {
 
-    fileprivate func setupRefreshControl() {
+    private func setupRefreshControl() {
       self.refreshControl = UIRefreshControl()
       self.refreshControl?.addTarget(self, action: #selector(self.tableViewPulledToRefresh(_:)), for: .valueChanged)
     }

--- a/Shared/Sources/MapViewController.swift
+++ b/Shared/Sources/MapViewController.swift
@@ -17,9 +17,9 @@ final class MapViewController: RevertViewController {
 
   // MARK: Private
 
-  fileprivate static let overlayLineWidth: CGFloat = 3
-  fileprivate static let overlayFillColor = UIColor(#colorLiteral(red: 0.208, green: 0.682, blue: 0.929, alpha: 1)).withAlphaComponent(0.5)
-  fileprivate static let overlayStrokeColor = #colorLiteral(red: 0.217, green: 0.372, blue: 1, alpha: 1)
+  private static let overlayLineWidth: CGFloat = 3
+  private static let overlayFillColor = UIColor(#colorLiteral(red: 0.208, green: 0.682, blue: 0.929, alpha: 1)).withAlphaComponent(0.5)
+  private static let overlayStrokeColor = #colorLiteral(red: 0.217, green: 0.372, blue: 1, alpha: 1)
 
   @IBOutlet private weak var mapView: MKMapView!
 

--- a/Shared/Sources/OpenGLViewController.swift
+++ b/Shared/Sources/OpenGLViewController.swift
@@ -53,7 +53,7 @@ final class OpenGLViewController: RevertGLKViewController {
     return self.view as! GLKView
   }
 
-  fileprivate func toggleState() {
+  private func toggleState() {
     self.isPaused = self.isPaused == false
   }
 }

--- a/Shared/Sources/RevealOpenGLCube.swift
+++ b/Shared/Sources/RevealOpenGLCube.swift
@@ -48,10 +48,10 @@ final class RevealOpenGLCube {
 
   // MARK: Private
 
-  fileprivate var vertexBuffer: GLuint = 0
-  fileprivate var indexBuffer: GLuint = 0
-  fileprivate var vertexArray: GLuint = 0
-  fileprivate let effect = GLKBaseEffect()
+  private var vertexBuffer: GLuint = 0
+  private var indexBuffer: GLuint = 0
+  private var vertexArray: GLuint = 0
+  private let effect = GLKBaseEffect()
   private var rotation: Float = 0
   private var computedModelViewMatrix: GLKMatrix4 {
     var matrix = GLKMatrix4MakeTranslation(0, 0, -6)

--- a/Shared/Sources/RevertItems.swift
+++ b/Shared/Sources/RevertItems.swift
@@ -60,10 +60,10 @@ enum RevertItems: String {
 
 extension RevertItems {
   #if os(iOS)
-    fileprivate static let platformSuffix = "_iOS"
+    private static let platformSuffix = "_iOS"
   #endif
 
   #if os(tvOS)
-    fileprivate static let platformSuffix = "_tvOS"
+    private static let platformSuffix = "_tvOS"
   #endif
 }


### PR DESCRIPTION
Plenty of properties and methods in the project are unnecessarily declared as `fileprivate`.
In fact, those properties and methods are not being called outside the class in the same file.

`fileprivate` declaration is also the style of older Swift language version.